### PR TITLE
Allow alternate xlcore directory

### DIFF
--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -126,13 +126,10 @@ class Program
         string? useAltPath = Environment.GetEnvironmentVariable("XL_PATH");
         try 
         {
-            // Try using the XL_PATH environment variable.
             storage = new Storage(APP_NAME, useAltPath);
         }
         catch (Exception e)
         {
-            // If it's somehow bad or we don't have permissions, just ignore it.
-            // Unfortunately, we can't log this easily, so here's a hacky workaround.
             storage = new Storage(APP_NAME);
             badxlpath = true;
             badxlpathex = e;
@@ -142,7 +139,7 @@ class Program
 
         if (badxlpath)
         {
-            Log.Error(badxlpathex, $"Bad value for XL_PATH={useAltPath}");
+            Log.Error(badxlpathex, $"Bad value for XL_PATH: {useAltPath}. Using ~/.xlcore instead.");
         }
 
         Secrets = GetSecretProvider(storage);

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -121,7 +121,8 @@ class Program
 
     private static void Main(string[] args)
     {
-        storage = new Storage(APP_NAME);
+        string? useAltPath = Environment.GetEnvironmentVariable("XL_PATH");
+        storage = new Storage(APP_NAME, useAltPath);
         SetupLogging(args);
         LoadConfig(storage);
 

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -124,7 +124,7 @@ class Program
         string? useAltPath = Environment.GetEnvironmentVariable("XL_PATH");
         try
         {
-            useAltPath = Path.GetFullPath("useAltPath");
+            Path.GetFullPath(useAltPath);
         }
         catch (Exception e)
         {

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -122,6 +122,14 @@ class Program
     private static void Main(string[] args)
     {
         string? useAltPath = Environment.GetEnvironmentVariable("XL_PATH");
+        try
+        {
+            useAltPath = Path.GetFullPath("useAltPath");
+        }
+        catch (Exception e)
+        {
+            useAltPath = null;
+        }
         storage = new Storage(APP_NAME, useAltPath);
         SetupLogging(args);
         LoadConfig(storage);

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -121,18 +121,29 @@ class Program
 
     private static void Main(string[] args)
     {
+        bool badxlpath = false;
+        var badxlpathex = new Exception();
         string? useAltPath = Environment.GetEnvironmentVariable("XL_PATH");
-        try
+        try 
         {
-            Path.GetFullPath(useAltPath);
+            // Try using the XL_PATH environment variable.
+            storage = new Storage(APP_NAME, useAltPath);
         }
         catch (Exception e)
         {
-            useAltPath = null;
+            // If it's somehow bad or we don't have permissions, just ignore it.
+            // Unfortunately, we can't log this easily, so here's a hacky workaround.
+            storage = new Storage(APP_NAME);
+            badxlpath = true;
+            badxlpathex = e;
         }
-        storage = new Storage(APP_NAME, useAltPath);
         SetupLogging(args);
         LoadConfig(storage);
+
+        if (badxlpath)
+        {
+            Log.Error(badxlpathex, $"Bad value for XL_PATH={useAltPath}");
+        }
 
         Secrets = GetSecretProvider(storage);
 


### PR DESCRIPTION
This PR creates an environment variable, `XL_PATH`, that allows the user to set a different launcher home directory. For example, by using `XL_PATH=$HOME/.local/share/xlcore /opt/XIVLauncher/XIVLauncher.Core`, the launcher will use (and create, if not present) the directory and download all the assets to that new folder. Since the `launcher.ini` file is contained in this folder, all settings are completely separate. So the user will still need to point the launcher to their game install for each unique folder they use.

I've been using this in my person build for a couple of weeks without issue. I use the default path for one account, and a second path for a non-steam free account.

This may also be useful for multi-boxing, as I've successfully run both accounts at the same time.