### PR TITLE
Fix LauncherApp.cs to work with latest XL. Update submodule.

### DIFF
--- a/src/XIVLauncher.Core/LauncherApp.cs
+++ b/src/XIVLauncher.Core/LauncherApp.cs
@@ -131,7 +131,7 @@ public class LauncherApp : Component
 
         this.Accounts = new AccountManager(this.Storage.GetFile("accounts.json"));
         this.UniqueIdCache = new CommonUniqueIdCache(this.Storage.GetFile("uidCache.json"));
-        this.Launcher = new Launcher(Program.Steam, UniqueIdCache, Program.CommonSettings);
+        this.Launcher = new Launcher(Program.Steam, UniqueIdCache, Program.CommonSettings, null);
 
         this.mainPage = new MainPage(this);
         this.setPage = new SettingsPage(this);


### PR DESCRIPTION
The latest commits to the main XL repo have a breaking change for XLCore. The Launcher class now has 4 arguments in its constructor instead of 3. This update adds that 4th argument (set to null since it is a valid value that is handled gracefully). It also points the submodule to the latest commit as of this PR (fc7208e) so it will actually build. (If the submodule still points to the original 1.0.2 commit, there are only 3 arguments and it errors out.)