### PR TITLE
fix: Use red Ban button for invalid settings

### DIFF
--- a/src/XIVLauncher.Core/Components/SettingsPage/SettingsPage.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/SettingsPage.cs
@@ -110,20 +110,25 @@ public class SettingsPage : Page
 
             var invalid = this.tabs.Any(x => x.Entries.Any(y => !y.IsValid));
             if (invalid)
-                ImGui.BeginDisabled();
-
-            if (ImGui.Button(FontAwesomeIcon.Check.ToIconString(), new Vector2(40)))
             {
-                foreach (var settingsTab in this.tabs)
-                {
-                    settingsTab.Save();
-                }
-
-                this.App.State = LauncherApp.LauncherState.Main;
-            }
-
-            if (invalid)
+                ImGui.BeginDisabled();
+                ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
+                ImGui.Button(FontAwesomeIcon.Ban.ToIconString(), new Vector2(40));
+                ImGui.PopStyleColor();
                 ImGui.EndDisabled();
+            }
+            else
+            {
+                if (ImGui.Button(FontAwesomeIcon.Check.ToIconString(), new Vector2(40)))
+                {
+                    foreach (var settingsTab in this.tabs)
+                    {
+                        settingsTab.Save();
+                    }
+
+                    this.App.State = LauncherApp.LauncherState.Main;
+                }
+            }
         }
 
         ImGui.EndChild();


### PR DESCRIPTION
When settings are invalid, instead of just making the check button un-clickable, replace it with a red ban button (circle with a slash through it). This gives better feedback to the user that something is wrong. This is particularly useful when the error is on another tab, in which case the user might just think the program is broken.