### PR TITLE
Fix wine prefix creation with custom wine

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -692,13 +692,13 @@ public class MainPage : Page
         else if (Environment.OSVersion.Platform == PlatformID.Unix)
         {
             if (App.Settings.WineStartupType == WineStartupType.Custom)
-            { 
+            {
                 if (App.Settings.WineBinaryPath == null)
                     throw new Exception("Custom wine binary path wasn't set.");
                 else if (!Directory.Exists(App.Settings.WineBinaryPath))
                     throw new Exception("Custom wine binary path is invalid: no such directory.\n" +
                         "Check path carefully for typos: " + App.Settings.WineBinaryPath);
-                else if (!File.Exists(App.Settings.WineBinaryPath + "/wine64"))
+                else if (!File.Exists(Path.Combine(App.Settings.WineBinaryPath,"wine64")))
                     throw new Exception("Custom wine binary path is invalid: no wine64 found at that location.\n" +
                         "Check path carefully for typos: " + App.Settings.WineBinaryPath);
             }


### PR DESCRIPTION
When using custom wine, the prefix creation will not finish properly. Specifically, dxvk will not get set up if you are using  custom wine. This is a launcher issue, not a wine issue. 

How to duplicate this bug:
1) Delete the wine prefix
2) Select custom wine, and then point it to the managed wine in ~/.xlcore/compatibilitytool/beta/wine-xiv-staging-fsync-git-7.10.r3.g560db77d/bin
3) Save and launch. The game will fail to run.

What this fix does:
* The section starting at line 694 currently doesn't really check if the custom wine path is valid, it just makes sure it isn't null. This first checks to see if the wine path is a directory, and then checks to see if that directory contains a file named wine64. If it doesn't, it throws errors.
* Since we now know that wine64 exists, the "if" statement for managed wine at line 700 is no longer needed, and the launcher can just run everything in that statement. That means the Program.CompatibilityTools.EnsureTool() method will always get run, which is needed to set up DXVK properly.
* You can now delete the wine prefix and launch the game with custom wine, and the prefix will be properly set up and the game will run.