### PR TITLE
feat: add DXVK settings tab

### DIFF
--- a/src/XIVLauncher.Core/Components/SettingsPage/SettingsPage.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/SettingsPage.cs
@@ -11,6 +11,7 @@ public class SettingsPage : Page
         new SettingsTabGame(),
         new SettingsTabPatching(),
         new SettingsTabWine(),
+        new SettingsTabDXVK(),
         new SettingsTabDalamud(),
         new SettingsTabAutoStart(),
         new SettingsTabAbout(),

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDXVK.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDXVK.cs
@@ -9,14 +9,32 @@ namespace XIVLauncher.Core.Components.SettingsPage.Tabs;
 
 public class SettingsTabDXVK : SettingsTab
 {
+    private SettingsEntry<Dxvk.DxvkVersion> dxvkVersionSetting;
     private SettingsEntry<Dxvk.DxvkHudType> dxvkHudSetting;
 
     public SettingsTabDXVK()
     {
         Entries = new SettingsEntry[]
         {
-            new SettingsEntry<Dxvk.DxvkVersion>("DXVK Version", "Choose which version of DXVK to use.", () => Program.Config.DxvkVersion ?? Dxvk.DxvkVersion.v1_10_3, type => Program.Config.DxvkVersion = type),
-            new SettingsEntry<bool>("Enable DXVK ASYNC", "Enable DXVK ASYNC patch.", () => Program.Config.DxvkAsyncEnabled ?? true, b => Program.Config.DxvkAsyncEnabled = b),
+            dxvkVersionSetting = new SettingsEntry<Dxvk.DxvkVersion>("DXVK Version", "Choose which version of DXVK to use.", () => Program.Config.DxvkVersion ?? Dxvk.DxvkVersion.v1_10_3, type => Program.Config.DxvkVersion = type)
+            {
+                CheckWarning = type =>
+                {
+                    if(type == Dxvk.DxvkVersion.v2_1)
+                        return "AMD users may need to use env variable RADV_PERFTEST=gpl";
+                    return null;
+                },
+            },
+            new SettingsEntry<bool>("Enable DXVK ASYNC", "Enable DXVK ASYNC patch.", () => Program.Config.DxvkAsyncEnabled ?? true, b => Program.Config.DxvkAsyncEnabled = b)
+            {
+                CheckVisibility = () => dxvkVersionSetting.Value != Dxvk.DxvkVersion.v2_1,
+                CheckWarning = b =>
+                {
+                    if(!b && dxvkVersionSetting.Value == Dxvk.DxvkVersion.v2_0)
+                        return "AMD users may need to use env variable RADV_PERFTEST=gpl";
+                    return null;
+                },
+            },
             dxvkHudSetting = new SettingsEntry<Dxvk.DxvkHudType>("DXVK Overlay", "DXVK Hud is included. MangoHud must be installed separately.\nFlatpak XIVLauncher needs flatpak MangoHud.", () => Program.Config.DxvkHudType, type => Program.Config.DxvkHudType = type)
             {
                 CheckValidity = type =>

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDXVK.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDXVK.cs
@@ -1,0 +1,66 @@
+using System.Numerics;
+using System.Runtime.InteropServices;
+using ImGuiNET;
+using XIVLauncher.Common.Unix.Compatibility;
+using XIVLauncher.Common.Util;
+
+namespace XIVLauncher.Core.Components.SettingsPage.Tabs;
+
+public class SettingsTabDXVK : SettingsTab
+{
+    private SettingsEntry<Dxvk.DxvkHudType> dxvkHudSetting;
+
+    public SettingsTabDXVK()
+    {
+        Entries = new SettingsEntry[]
+        {
+            new SettingsEntry<Dxvk.DxvkVersion>("DXVK Version", "Choose which version of DXVK to use.", () => Program.Config.DxvkVersion, type => Program.Config.DxvkVersion = type),
+            new SettingsEntry<bool>("Enable DXVK ASYNC", "Enable DXVK ASYNC patch.", () => Program.Config.DxvkAsyncEnabled ?? true, b => Program.Config.DxvkAsyncEnabled = b),
+            dxvkHudSetting = new SettingsEntry<Dxvk.DxvkHudType>("DXVK Overlay", "DXVK Hud is included. MangoHud must be installed separately.\nFlatpak XIVLauncher needs flatpak MangoHud.", () => Program.Config.DxvkHudType, type => Program.Config.DxvkHudType = type)
+            {
+                CheckValidity = type =>
+                {
+                    if ((type == Dxvk.DxvkHudType.MangoHud || type == Dxvk.DxvkHudType.MangoHudCustom || type == Dxvk.DxvkHudType.MangoHudFull)
+                        && (!File.Exists("/usr/lib/mangohud/libMangoHud.so") && !File.Exists("/usr/lib/extensions/vulkan/MangoHud/lib/x86_64-linux-gnu/libMangoHud.so")))
+                        return "MangoHud not detected.";
+
+                    return null;
+                }
+            },
+            new SettingsEntry<string>("DXVK Hud Custom String", "Set a custom string for the built in DXVK Hud. Warning: If it's invalid, the game may hang.", () => Program.Config.DxvkHudCustom, s => Program.Config.DxvkHudCustom = s)
+            {
+                CheckVisibility = () => dxvkHudSetting.Value == Dxvk.DxvkHudType.Custom,
+                CheckWarning = s =>
+                {
+                    if(!DxvkSettings.CheckDxvkHudString(s))
+                        return "That's not a valid hud string";
+                    return null;
+                },
+            },
+            new SettingsEntry<string>("MangoHud Custom Path", "Set a custom path for MangoHud config file.", () => Program.Config.DxvkMangoCustom, s => Program.Config.DxvkMangoCustom = s)
+            {
+                CheckVisibility = () => dxvkHudSetting.Value == Dxvk.DxvkHudType.MangoHudCustom,
+                CheckWarning = s =>
+                {
+                    if(!DxvkSettings.CheckMangoHudPath(s))
+                        return "That's not a valid file.";
+                    return null;
+                },
+            },
+            new NumericSettingsEntry("Frame Rate Limit", "Set a frame rate limit, and DXVK will try not exceed it. Use 0 to leave unset.", () => Program.Config.DxvkFrameRate ?? 0, i => Program.Config.DxvkFrameRate = i, 0, 1000),
+        };
+    }
+
+    public override SettingsEntry[] Entries { get; }
+
+    public override bool IsUnixExclusive => true;
+
+    public override string Title => "DXVK";
+
+    public override void Save()
+    {
+        base.Save();
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            Program.CreateCompatToolsInstance();
+    }
+}

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDXVK.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDXVK.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using ImGuiNET;
@@ -42,12 +43,12 @@ public class SettingsTabDXVK : SettingsTab
                 CheckVisibility = () => dxvkHudSetting.Value == Dxvk.DxvkHudType.MangoHudCustom,
                 CheckWarning = s =>
                 {
-                    if(!DxvkSettings.CheckMangoHudPath(s))
+                    if(!File.Exists(s))
                         return "That's not a valid file.";
                     return null;
                 },
             },
-            new NumericSettingsEntry("Frame Rate Limit", "Set a frame rate limit, and DXVK will try not exceed it. Use 0 to leave unset.", () => Program.Config.DxvkFrameRate ?? 0, i => Program.Config.DxvkFrameRate = i, 0, 1000),
+            new NumericSettingsEntry("Frame Rate Limit", "Set a frame rate limit, and DXVK will try not exceed it. Use 0 for unlimited.", () => Program.Config.DxvkFrameRate ?? 0, i => Program.Config.DxvkFrameRate = i, 0, 1000),
         };
     }
 

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDXVK.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDXVK.cs
@@ -40,7 +40,7 @@ public class SettingsTabDXVK : SettingsTab
                 CheckValidity = type =>
                 {
                     if ((type == Dxvk.DxvkHudType.MangoHud || type == Dxvk.DxvkHudType.MangoHudCustom || type == Dxvk.DxvkHudType.MangoHudFull)
-                        && (!File.Exists("/usr/lib/mangohud/libMangoHud.so") && !File.Exists("/usr/lib/extensions/vulkan/MangoHud/lib/x86_64-linux-gnu/libMangoHud.so")))
+                        && (!File.Exists("/usr/lib/mangohud/libMangoHud.so") && !File.Exists("/usr/lib64/mangohud/libMangoHud.so") && !File.Exists("/usr/lib/extensions/vulkan/MangoHud/lib/x86_64-linux-gnu/libMangoHud.so")))
                         return "MangoHud not detected.";
 
                     return null;

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDXVK.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDXVK.cs
@@ -15,7 +15,7 @@ public class SettingsTabDXVK : SettingsTab
     {
         Entries = new SettingsEntry[]
         {
-            new SettingsEntry<Dxvk.DxvkVersion>("DXVK Version", "Choose which version of DXVK to use.", () => Program.Config.DxvkVersion, type => Program.Config.DxvkVersion = type),
+            new SettingsEntry<Dxvk.DxvkVersion>("DXVK Version", "Choose which version of DXVK to use.", () => Program.Config.DxvkVersion ?? Dxvk.DxvkVersion.v1_10_3, type => Program.Config.DxvkVersion = type),
             new SettingsEntry<bool>("Enable DXVK ASYNC", "Enable DXVK ASYNC patch.", () => Program.Config.DxvkAsyncEnabled ?? true, b => Program.Config.DxvkAsyncEnabled = b),
             dxvkHudSetting = new SettingsEntry<Dxvk.DxvkHudType>("DXVK Overlay", "DXVK Hud is included. MangoHud must be installed separately.\nFlatpak XIVLauncher needs flatpak MangoHud.", () => Program.Config.DxvkHudType, type => Program.Config.DxvkHudType = type)
             {

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDXVK.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDXVK.cs
@@ -20,17 +20,17 @@ public class SettingsTabDXVK : SettingsTab
             {
                 CheckWarning = type =>
                 {
-                    if(type == Dxvk.DxvkVersion.v2_1)
-                        return "AMD users may need to use env variable RADV_PERFTEST=gpl";
+                    if (new [] {Dxvk.DxvkVersion.v2_1, Dxvk.DxvkVersion.v2_2}.Contains(type))
+                        return "May not work with pre-8.0 or non-proton wine builds. AMD users may need to use env variable RADV_PERFTEST=gpl";
                     return null;
                 },
             },
             new SettingsEntry<bool>("Enable DXVK ASYNC", "Enable DXVK ASYNC patch.", () => Program.Config.DxvkAsyncEnabled ?? true, b => Program.Config.DxvkAsyncEnabled = b)
             {
-                CheckVisibility = () => dxvkVersionSetting.Value != Dxvk.DxvkVersion.v2_1,
+                CheckVisibility = () => !(new [] {Dxvk.DxvkVersion.v2_1, Dxvk.DxvkVersion.v2_2}.Contains(dxvkVersionSetting.Value)),
                 CheckWarning = b =>
                 {
-                    if(!b && dxvkVersionSetting.Value == Dxvk.DxvkVersion.v2_0)
+                    if (!b && dxvkVersionSetting.Value == Dxvk.DxvkVersion.v2_0)
                         return "AMD users may need to use env variable RADV_PERFTEST=gpl";
                     return null;
                 },

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -49,7 +49,10 @@ public class SettingsTabWine : SettingsTab
                 }
             },
 
-            new SettingsEntry<string>("WINEDEBUG Variables", "Configure debug logging for wine. Useful for troubleshooting.", () => Program.Config.WineDebugVars ?? string.Empty, s => Program.Config.WineDebugVars = s)
+            new SettingsEntry<string>("WINEDEBUG Variables", "Configure debug logging for wine. Useful for troubleshooting.", () => Program.Config.WineDebugVars ?? string.Empty, s => Program.Config.WineDebugVars = s),
+            new SettingsEntry<bool>("Use WineD3D (Disable DXVK)",
+                                    "Don't check this unless you know what you're doing.\nIf you check this, XIVLauncher will try to use WineD3D instead of DXVK, and nothing in the DXVK tab will work.\nCustom wine versions may not work (especially proton-based wine). This will also break GShade.",
+                                    () => Program.Config.WineD3DEnabled ?? false, b => Program.Config.WineD3DEnabled = b),        
         };
     }
 

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -36,7 +36,6 @@ public class SettingsTabWine : SettingsTab
                 }
             },
 
-            new SettingsEntry<bool>("Enable DXVK ASYNC", "Enable DXVK ASYNC patch.", () => Program.Config.DxvkAsyncEnabled ?? true, b => Program.Config.DxvkAsyncEnabled = b),
             new SettingsEntry<bool>("Enable ESync", "Enable eventfd-based synchronization.", () => Program.Config.ESyncEnabled ?? true, b => Program.Config.ESyncEnabled = b),
             new SettingsEntry<bool>("Enable FSync", "Enable fast user mutex (futex2).", () => Program.Config.FSyncEnabled ?? true, b => Program.Config.FSyncEnabled = b)
             {
@@ -50,7 +49,6 @@ public class SettingsTabWine : SettingsTab
                 }
             },
 
-            new SettingsEntry<Dxvk.DxvkHudType>("DXVK Overlay", "Configure how much of the DXVK overlay is to be shown.", () => Program.Config.DxvkHudType, type => Program.Config.DxvkHudType = type),
             new SettingsEntry<string>("WINEDEBUG Variables", "Configure debug logging for wine. Useful for troubleshooting.", () => Program.Config.WineDebugVars ?? string.Empty, s => Program.Config.WineDebugVars = s)
         };
     }

--- a/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
+++ b/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
@@ -66,13 +66,21 @@ public interface ILauncherConfig
 
     public bool? GameModeEnabled { get; set; }
 
+    public Dxvk.DxvkVersion DxvkVersion { get; set; }
+
     public bool? DxvkAsyncEnabled { get; set; }
+
+    public int? DxvkFrameRate { get; set; }
 
     public bool? ESyncEnabled { get; set; }
 
     public bool? FSyncEnabled { get; set; }
 
     public Dxvk.DxvkHudType DxvkHudType { get; set; }
+
+    public string? DxvkHudCustom { get; set; }
+
+    public string? DxvkMangoCustom { get; set; }
 
     public string? WineDebugVars { get; set; }
 

--- a/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
+++ b/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
@@ -68,7 +68,7 @@ public interface ILauncherConfig
 
     public bool? WineD3DEnabled { get; set; }
 
-    public Dxvk.DxvkVersion DxvkVersion { get; set; }
+    public Dxvk.DxvkVersion? DxvkVersion { get; set; }
 
     public bool? DxvkAsyncEnabled { get; set; }
 

--- a/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
+++ b/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
@@ -66,6 +66,8 @@ public interface ILauncherConfig
 
     public bool? GameModeEnabled { get; set; }
 
+    public bool? WineD3DEnabled { get; set; }
+
     public Dxvk.DxvkVersion DxvkVersion { get; set; }
 
     public bool? DxvkAsyncEnabled { get; set; }

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -107,12 +107,13 @@ class Program
         Config.GlobalScale ??= 1.0f;
 
         Config.GameModeEnabled ??= false;
+        Config.WineD3DEnabled ??= false;
         Config.DxvkAsyncEnabled ??= true;
         Config.DxvkFrameRate ??= 0;
         Config.ESyncEnabled ??= true;
         Config.FSyncEnabled ??= false;
         Config.DxvkHudCustom ??= "fps,frametimes,gpuload,version";
-        Config.DxvkMangoCustom ??= Environment.GetEnvironmentVariable("HOME") + "/.config/MangoHud/MangoHud.conf";
+        Config.DxvkMangoCustom ??= Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".config", "MangoHud", "MangoHud.conf");
 
         Config.WineStartupType ??= WineStartupType.Managed;
         Config.WineBinaryPath ??= "/usr/bin";
@@ -278,7 +279,7 @@ class Program
         var winePrefix = storage.GetFolder("wineprefix");
         var wineSettings = new WineSettings(Config.WineStartupType, Config.WineBinaryPath, Config.WineDebugVars, wineLogFile, winePrefix, Config.ESyncEnabled, Config.FSyncEnabled);
         var toolsFolder = storage.GetFolder("compatibilitytool");
-        var dxvkSettings = new DxvkSettings(Config.DxvkHudType, Config.DxvkHudCustom, Config.DxvkMangoCustom, Config.DxvkAsyncEnabled, Config.DxvkFrameRate, Config.DxvkVersion, storage.Root);
+        var dxvkSettings = new DxvkSettings(Config.DxvkHudType, storage.Root, Config.DxvkVersion, !Config.WineD3DEnabled ?? true, Config.DxvkHudCustom, new FileInfo(Config.DxvkMangoCustom), Config.DxvkAsyncEnabled ?? true, Config.DxvkFrameRate ?? 0);
         CompatibilityTools = new CompatibilityTools(wineSettings, dxvkSettings, Config.GameModeEnabled, toolsFolder);
     }
 

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -108,8 +108,11 @@ class Program
 
         Config.GameModeEnabled ??= false;
         Config.DxvkAsyncEnabled ??= true;
+        Config.DxvkFrameRate ??= 0;
         Config.ESyncEnabled ??= true;
         Config.FSyncEnabled ??= false;
+        Config.DxvkHudCustom ??= "fps,frametimes,gpuload,version";
+        Config.DxvkMangoCustom ??= Environment.GetEnvironmentVariable("HOME") + "/.config/MangoHud/MangoHud.conf";
 
         Config.WineStartupType ??= WineStartupType.Managed;
         Config.WineBinaryPath ??= "/usr/bin";
@@ -275,7 +278,8 @@ class Program
         var winePrefix = storage.GetFolder("wineprefix");
         var wineSettings = new WineSettings(Config.WineStartupType, Config.WineBinaryPath, Config.WineDebugVars, wineLogFile, winePrefix, Config.ESyncEnabled, Config.FSyncEnabled);
         var toolsFolder = storage.GetFolder("compatibilitytool");
-        CompatibilityTools = new CompatibilityTools(wineSettings, Config.DxvkHudType, Config.GameModeEnabled, Config.DxvkAsyncEnabled, toolsFolder);
+        var dxvkSettings = new DxvkSettings(Config.DxvkHudType, Config.DxvkHudCustom, Config.DxvkMangoCustom, Config.DxvkAsyncEnabled, Config.DxvkFrameRate, Config.DxvkVersion, storage.Root);
+        CompatibilityTools = new CompatibilityTools(wineSettings, dxvkSettings, Config.GameModeEnabled, toolsFolder);
     }
 
     public static void ShowWindow()

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -108,6 +108,7 @@ class Program
 
         Config.GameModeEnabled ??= false;
         Config.WineD3DEnabled ??= false;
+        Config.DxvkVersion ??= Dxvk.DxvkVersion.v1_10_3;
         Config.DxvkAsyncEnabled ??= true;
         Config.DxvkFrameRate ??= 0;
         Config.ESyncEnabled ??= true;
@@ -279,7 +280,7 @@ class Program
         var winePrefix = storage.GetFolder("wineprefix");
         var wineSettings = new WineSettings(Config.WineStartupType, Config.WineBinaryPath, Config.WineDebugVars, wineLogFile, winePrefix, Config.ESyncEnabled, Config.FSyncEnabled);
         var toolsFolder = storage.GetFolder("compatibilitytool");
-        var dxvkSettings = new DxvkSettings(Config.DxvkHudType, storage.Root, Config.DxvkVersion, !Config.WineD3DEnabled ?? true, Config.DxvkHudCustom, new FileInfo(Config.DxvkMangoCustom), Config.DxvkAsyncEnabled ?? true, Config.DxvkFrameRate ?? 0);
+        var dxvkSettings = new DxvkSettings(Config.DxvkHudType, storage.Root, Config.DxvkVersion ?? Dxvk.DxvkVersion.v1_10_3, !Config.WineD3DEnabled ?? true, Config.DxvkHudCustom, new FileInfo(Config.DxvkMangoCustom), Config.DxvkAsyncEnabled ?? true, Config.DxvkFrameRate ?? 0);
         CompatibilityTools = new CompatibilityTools(wineSettings, dxvkSettings, Config.GameModeEnabled, toolsFolder);
     }
 


### PR DESCRIPTION
Here's the XL.Core side of the DXVK settings patch. This requires [PR #1205](https://github.com/goatcorp/FFXIVQuickLauncher/pull/1205) from FFXIVQuickLauncher to work, otherwise it will not compile. ~~I also suggest adding [PR #13](https://github.com/goatcorp/XIVLauncher.Core/pull/13), and [PR #15](https://github.com/goatcorp/XIVLauncher.Core/pull/15), since those improve the UI to expose more information and make it more consistant.~~ Edit: These PRs have been added already.

* Added DXVK tab to settings.
* Moved a few settings from wine tab to DXVK tab.
* Added dxvk-related settings to launcher.ini.
* Updated CreateCompatToolsInstance to work with new dxvkSettings object.