### PR TITLE
Added option to ignore steam (Just skips the initialise calls if true)

### DIFF
--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
@@ -38,7 +38,7 @@ public class SettingsTabGame : SettingsTab
         new SettingsEntry<DpiAwareness>("Game DPI Awareness", "Select the game's DPI Awareness. Change this if the game's scaling looks wrong.", () => Program.Config.DpiAwareness ?? DpiAwareness.Unaware, x => Program.Config.DpiAwareness = x),
         new SettingsEntry<bool>("Free trial account", "Check this if you are using a free trial account.", () => Program.Config.IsFt ?? false, x => Program.Config.IsFt = x),
         new SettingsEntry<bool>("Use XIVLauncher authenticator/OTP macros", "Check this if you want to use the XIVLauncher authenticator app or macros.", () => Program.Config.IsOtpServer ?? false, x => Program.Config.IsOtpServer = x),
-        new SettingsEntry<bool>("Ignore Steam (Requires Restart)", "Check this if you do not want XIVLauncher to communicate with Steam.", () => Program.Config.IsIgnoringSteam ?? false, x => Program.Config.IsIgnoringSteam = x),
+        new SettingsEntry<bool>("Ignore Steam", "Check this if you do not want XIVLauncher to communicate with Steam (Requires Restart).", () => Program.Config.IsIgnoringSteam ?? false, x => Program.Config.IsIgnoringSteam = x),
     };
 
     public override string Title => "Game";

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
@@ -38,6 +38,7 @@ public class SettingsTabGame : SettingsTab
         new SettingsEntry<DpiAwareness>("Game DPI Awareness", "Select the game's DPI Awareness. Change this if the game's scaling looks wrong.", () => Program.Config.DpiAwareness ?? DpiAwareness.Unaware, x => Program.Config.DpiAwareness = x),
         new SettingsEntry<bool>("Free trial account", "Check this if you are using a free trial account.", () => Program.Config.IsFt ?? false, x => Program.Config.IsFt = x),
         new SettingsEntry<bool>("Use XIVLauncher authenticator/OTP macros", "Check this if you want to use the XIVLauncher authenticator app or macros.", () => Program.Config.IsOtpServer ?? false, x => Program.Config.IsOtpServer = x),
+        new SettingsEntry<bool>("Ignore Steam", "Check this if you do not want XIVLauncher to communicate with Steam", () => Program.Config.IsIgnoringSteam ?? false, x => Program.Config.IsIgnoringSteam = x),
     };
 
     public override string Title => "Game";

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
@@ -38,7 +38,7 @@ public class SettingsTabGame : SettingsTab
         new SettingsEntry<DpiAwareness>("Game DPI Awareness", "Select the game's DPI Awareness. Change this if the game's scaling looks wrong.", () => Program.Config.DpiAwareness ?? DpiAwareness.Unaware, x => Program.Config.DpiAwareness = x),
         new SettingsEntry<bool>("Free trial account", "Check this if you are using a free trial account.", () => Program.Config.IsFt ?? false, x => Program.Config.IsFt = x),
         new SettingsEntry<bool>("Use XIVLauncher authenticator/OTP macros", "Check this if you want to use the XIVLauncher authenticator app or macros.", () => Program.Config.IsOtpServer ?? false, x => Program.Config.IsOtpServer = x),
-        new SettingsEntry<bool>("Ignore Steam", "Check this if you do not want XIVLauncher to communicate with Steam", () => Program.Config.IsIgnoringSteam ?? false, x => Program.Config.IsIgnoringSteam = x),
+        new SettingsEntry<bool>("Ignore Steam (Requires Restart)", "Check this if you do not want XIVLauncher to communicate with Steam.", () => Program.Config.IsIgnoringSteam ?? false, x => Program.Config.IsIgnoringSteam = x),
     };
 
     public override string Title => "Game";

--- a/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
+++ b/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
@@ -46,6 +46,8 @@ public interface ILauncherConfig
 
     public bool? IsOtpServer { get; set; }
 
+    public bool? IsIgnoringSteam { get; set; }
+
     #region Patching
 
     public DirectoryInfo? PatchPath { get; set; }

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -97,6 +97,7 @@ class Program
         Config.IsEncryptArgs ??= true;
         Config.IsFt ??= false;
         Config.IsOtpServer ??= false;
+        Config.IsIgnoringSteam ??= false;
 
         Config.PatchPath ??= storage.GetFolder("patch");
         Config.PatchAcquisitionMethod ??= AcquisitionMethod.Aria;
@@ -144,16 +145,18 @@ class Program
                 default:
                     throw new PlatformNotSupportedException();
             }
-
-            try
+            if (!Config.IsIgnoringSteam ?? true)
             {
-                var appId = Config.IsFt == true ? STEAM_APP_ID_FT : STEAM_APP_ID;
-                Steam.Initialize(appId);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Couldn't init Steam with game AppIds, trying FT");
-                Steam.Initialize(STEAM_APP_ID_FT);
+                try
+                {
+                    var appId = Config.IsFt == true ? STEAM_APP_ID_FT : STEAM_APP_ID;
+                    Steam.Initialize(appId);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Couldn't init Steam with game AppIds, trying FT");
+                    Steam.Initialize(STEAM_APP_ID_FT);
+                }
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
Alright, I couldn't sleep. Here's the pull request to match the issue: https://github.com/goatcorp/XIVLauncher.Core/issues/18

Was done quickly, seems to work.