### PR TITLE
Don't warn about updates at all

### DIFF
--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -202,16 +202,6 @@ class Program
 
         var needUpdate = false;
 
-#if FLATPAK
-        if (Config.DoVersionCheck ?? false)
-        {
-            var versionCheckResult = UpdateCheck.CheckForUpdate().GetAwaiter().GetResult();
-
-            if (versionCheckResult.Success)
-                needUpdate = versionCheckResult.NeedUpdate;
-        }   
-#endif
-
         launcherApp = new LauncherApp(storage, needUpdate);
 
         Invalidate(20);


### PR DESCRIPTION
Update checking on Linux inside of an app is generally useless, as it can't update itself (I think Flatpak has a dedicated portal for that, but I doubt this app uses that).

Update checking is better done inside of the package manager itself, in this case Flatpak. Additionally, only checking for updates on Flatpak builds seems unfair to flatpak builds, in a way.