### PR TITLE
Bump nixpkgs stable link to 22.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ XIVLauncher Core has community packages for various Linux distributions. Please 
 | [AUR](https://aur.archlinux.org/packages/xivlauncher) | ![AUR version](https://img.shields.io/aur/version/xivlauncher) |
 | [AUR (git)](https://aur.archlinux.org/packages/xivlauncher-git) | ![AUR version](https://img.shields.io/aur/version/xivlauncher-git) |
 | [MPR (Debian+Ubuntu)](https://mpr.makedeb.org/packages/xivlauncher)  | ![MPR package](https://repology.org/badge/version-for-repo/mpr/xivlauncher.svg?header=MPR) |
-| [nixpkgs stable](https://search.nixos.org/packages?channel=22.05&from=0&size=50&sort=relevance&type=packages&query=xivlauncher) | ![nixpkgs stable version](https://repology.org/badge/version-for-repo/nix_stable_22_05/xivlauncher.svg?header=nixpkgs%2022.05) |
+| [nixpkgs stable](https://search.nixos.org/packages?channel=22.11&from=0&size=50&sort=relevance&type=packages&query=xivlauncher) | ![nixpkgs stable version](https://repology.org/badge/version-for-repo/nix_stable_22_11/xivlauncher.svg?header=nixpkgs%2022.11) |
 | [nixpkgs unstable](https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=xivlauncher) | ![nixpkgs unstable version](https://repology.org/badge/version-for-repo/nix_unstable/xivlauncher.svg?header=nixpkgs%20unstable) |
 | [Copr (Fedora+openSuse+EL9)](https://copr.fedorainfracloud.org/coprs/rankyn/xivlauncher/) | ![COPR version](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frankynbass%2FXIVLauncher4rpm%2Fmain%2Fbadge.json)|


### PR DESCRIPTION
NixOS 22.11 released at the end of last month, and is the new stable version. (xlcore 1.0.2 never actually made it into 22.05, frustratingly; the PR just sat around and never got merged.)