### PR TITLE
Add CI workflows for build & flatpak releases

### DIFF
--- a/.github/scripts/update_flatpak_manifest.py
+++ b/.github/scripts/update_flatpak_manifest.py
@@ -1,0 +1,34 @@
+import yaml
+import sys
+
+if len(sys.argv) != 4:
+    print(f'Usage: python3 {sys.argv[0]} <config file> <new tag number> <new commit hash>')
+    sys.exit(1)
+
+fileName = sys.argv[1]
+newTag = sys.argv[2]
+newCommit = sys.argv[3]
+
+# Read the given file and try to parse it to update its tag and commit.
+with open(fileName, 'r') as f:
+    config = yaml.safe_load(f)
+    success = False
+    try:
+        for module in config['modules']:
+            if module['name'] == 'xivlauncher':
+                for source in module['sources']:
+                    if source['url'] == 'https://github.com/goatcorp/XIVLauncher.Core.git':
+                        source['tag'] = newTag
+                        source['commit'] = newCommit
+                        with open(fileName, 'w') as f:
+                            yaml.dump(config, f)
+                            success = True
+                            break;
+    except KeyError:
+        pass
+
+    if success is False:
+        print('Error: failed to update XIVLauncher.Core commit and tag.. exiting')
+        sys.exit(1)
+
+    print(f'Updated XIVLauncher.Core tag to {newTag} and commit to {newCommit} in {fileName}')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: "Build XLCore"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.head_ref }}"
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Restore
+        working-directory: ./src/XIVLauncher.Core/
+        run: dotnet restore
+
+      - name: Build
+        working-directory: ./src/XIVLauncher.Core/
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: XIVLauncher.Core
+          path: ./src/XIVLauncher.Core/bin/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,21 +20,47 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Setup .NET Core
+      - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
 
-      - name: Restore
+      - name: Dotnet Restore
         working-directory: ./src/XIVLauncher.Core/
         run: dotnet restore
 
-      - name: Build
+      - name: Dotnet Build (Default)
         working-directory: ./src/XIVLauncher.Core/
-        run: dotnet build --configuration Release --no-restore
+        run: |
+          rm -rf bin
+          dotnet build --configuration Release --no-restore
 
-      - name: Upload Artifacts
+      - name: Upload Artifact (Default)
         uses: actions/upload-artifact@v3
         with:
-          name: XIVLauncher.Core
+          name: XIVLauncher.Core-default
+          path: ./src/XIVLauncher.Core/bin/
+
+      - name: Dotnet Build (Arch)
+        working-directory: ./src/XIVLauncher.Core/
+        run: |
+          rm -rf bin
+          dotnet build --configuration Release -p:DefineConstants=WINE_XIV_ARCH_LINUX --no-restore
+        
+      - name: Upload Artifacts (Arch)
+        uses: actions/upload-artifact@v3
+        with:
+          name: XIVLauncher.Core-arch
+          path: ./src/XIVLauncher.Core/bin/
+
+      - name: Dotnet Build (Fedora)
+        working-directory: ./src/XIVLauncher.Core/
+        run: |
+          rm -rf bin
+          dotnet build --configuration Release -p:DefineConstants=WINE_XIV_FEDORA_LINUX --no-restore
+
+      - name: Upload Artifacts (Fedora)
+        uses: actions/upload-artifact@v3
+        with:
+          name: XIVLauncher.Core-fedora
           path: ./src/XIVLauncher.Core/bin/

--- a/.github/workflows/flatpak-to-pr.yml
+++ b/.github/workflows/flatpak-to-pr.yml
@@ -1,0 +1,86 @@
+name: "PR XLCore to Flatpak"
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+    env:
+      FLATHUB_REPO: https://github.com/flathub/dev.goats.xivlauncher.git
+      FLATHUB_MANIFEST: dev.goats.xivlauncher.yml
+      COMMIT_USER: github-actions[bot]
+      COMMIT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Setup Commit Author
+        run: |
+          git config --global user.name $COMMIT_USER
+          git config --global user.email $COMMIT_EMAIL
+          git config --global pull.rebase false
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Dotnet Restore
+        working-directory: ./src/XIVLauncher.Core/
+        run: dotnet restore
+
+      - name: Dotnet Build
+        working-directory: ./src/XIVLauncher.Core/
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Setup Python3
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+
+      - name: Setup Flatpak
+        run: |
+          sudo apt update -y
+          sudo apt install flatpak flatpak-builder -y
+          flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo 
+          flatpak install --user org.freedesktop.Sdk.Extension.dotnet6/x86_64/21.08 -y
+          flatpak install --user org.freedesktop.Sdk/x86_64/21.08 -y
+
+      - name: Generate nuget-dependencies.json
+        working-directory: ./src/XIVLauncher.Core/
+        run: |
+          curl -LO https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/dotnet/flatpak-dotnet-generator.py
+          python3 flatpak-dotnet-generator.py nuget-dependencies.json XIVLauncher.Core.csproj
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: XIVLauncher.Core
+          path: |
+            ./src/XIVLauncher.Core/bin/
+            ./src/XIVLauncher.Core/nuget-dependencies.json
+
+      - name: Make PR to Flatpak repository
+        run: |
+          git clone $FLATHUB_REPO /tmp/xlcore-flatpak
+          mv ./src/XIVLauncher.Core/nuget-dependencies.json /tmp/xlcore-flatpak/
+          mv ./.github/scripts/update_flatpak_manifest.py /tmp/xlcore-flatpak/
+          cd /tmp/xlcore-flatpak
+
+          python3 -m pip install pyyaml
+          python3 update_flatpak_manifest.py $FLATHUB_MANIFEST $(echo ${{ github.ref_name }} | sed -e "s/^v//g") ${{ github.sha }}
+          rm update_flatpak_manifest.py
+
+          git checkout -b xlcore-${{ github.ref_name }}
+          git add .
+          git commit -m "Update XIVLauncher.Core to ${{ github.ref_name }}"
+          git push -u origin xlcore-${{ github.ref_name }}
+
+          gh login --with-token <<< ${{ secrets.PUSH_TOKEN }}
+          gh pr create --title "Update XIVLauncher.Core to ${{ github.ref_name }}" --body "Update XIVLauncher.Core to ${{ github.ref_name }}" --base main --head xlcore-${{ github.ref_name }} --repo $FLATHUB_REPO

--- a/.github/workflows/flatpak-to-pr.yml
+++ b/.github/workflows/flatpak-to-pr.yml
@@ -9,8 +9,6 @@ jobs:
   Release:
     runs-on: ubuntu-latest
     env:
-      FLATHUB_REPO: https://github.com/flathub/dev.goats.xivlauncher.git
-      FLATHUB_MANIFEST: dev.goats.xivlauncher.yml
       COMMIT_USER: github-actions[bot]
       COMMIT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
     steps:
@@ -47,7 +45,7 @@ jobs:
       - name: Setup Flatpak
         run: |
           sudo apt update -y
-          sudo apt install flatpak flatpak-builder -y
+          sudo apt install flatpak -y
           flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo 
           flatpak install --user org.freedesktop.Sdk.Extension.dotnet6/x86_64/21.08 -y
           flatpak install --user org.freedesktop.Sdk/x86_64/21.08 -y
@@ -68,19 +66,20 @@ jobs:
 
       - name: Make PR to Flatpak repository
         run: |
-          git clone $FLATHUB_REPO /tmp/xlcore-flatpak
+          echo ${{ secrets.PUSH_TOKEN }}| gh auth login --with-token
+
+          git clone https://${{ secrets.PUSH_TOKEN }}@github.com/flathub/dev.goats.xivlauncher /tmp/xlcore-flatpak
           mv ./src/XIVLauncher.Core/nuget-dependencies.json /tmp/xlcore-flatpak/
           mv ./.github/scripts/update_flatpak_manifest.py /tmp/xlcore-flatpak/
           cd /tmp/xlcore-flatpak
 
           python3 -m pip install pyyaml
-          python3 update_flatpak_manifest.py $FLATHUB_MANIFEST $(echo ${{ github.ref_name }} | sed -e "s/^v//g") ${{ github.sha }}
+          python3 update_flatpak_manifest.py dev.goats.xivlauncher.yml $(echo ${{ github.ref_name }} | sed -e "s/^v//g") ${{ github.sha }}
           rm update_flatpak_manifest.py
 
           git checkout -b xlcore-${{ github.ref_name }}
           git add .
           git commit -m "Update XIVLauncher.Core to ${{ github.ref_name }}"
-          git push -u origin xlcore-${{ github.ref_name }}
+          git push --set-upstream origin xlcore-${{ github.ref_name }}
 
-          gh login --with-token <<< ${{ secrets.PUSH_TOKEN }}
-          gh pr create --title "Update XIVLauncher.Core to ${{ github.ref_name }}" --body "Update XIVLauncher.Core to ${{ github.ref_name }}" --base main --head xlcore-${{ github.ref_name }} --repo $FLATHUB_REPO
+          gh pr create -t "Update XIVLauncher.Core to ${{ github.ref_name }}" -b "This is an automated pull request" -B master

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -24,7 +24,7 @@ jobs:
           git config --global user.email $COMMIT_EMAIL
           git config --global pull.rebase false
 
-      - name: Setup .NET Core
+      - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
@@ -56,12 +56,11 @@ jobs:
           curl -LO https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/dotnet/flatpak-dotnet-generator.py
           python3 flatpak-dotnet-generator.py nuget-dependencies.json XIVLauncher.Core.csproj
 
-      - name: Upload Artifacts
+      - name: Upload nuget-dependencies.json
         uses: actions/upload-artifact@v3
         with:
-          name: XIVLauncher.Core
+          name: nuget-dependencies
           path: |
-            ./src/XIVLauncher.Core/bin/
             ./src/XIVLauncher.Core/nuget-dependencies.json
 
       - name: Make PR to Flatpak repository
@@ -83,3 +82,8 @@ jobs:
           git push --set-upstream origin xlcore-${{ github.ref_name }}
 
           gh pr create -t "Update XIVLauncher.Core to ${{ github.ref_name }}" -b "This is an automated pull request" -B master
+          
+      - name: Release on GitHub
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
Adds CI to automatically build on every PR/Push, and automatically update the FlatHub manifest & NuGet dependencies file on a new tag.

A repository secret `PUSH_TOKEN` will need to be created with the scopes to access & push to the Flathub repository.

Example PR for Flathub:
https://github.com/BitsOfAByte/dev.goats.xivlauncher/pull/1

Closes #1 