### PR TITLE
Add appstream support to flathub update script

### DIFF
--- a/.github/scripts/update_flatpak_manifest.py
+++ b/.github/scripts/update_flatpak_manifest.py
@@ -1,34 +1,54 @@
 import yaml
 import sys
+import xml.etree.ElementTree as ET
+from datetime import date
 
-if len(sys.argv) != 4:
-    print(f'Usage: python3 {sys.argv[0]} <config file> <new tag number> <new commit hash>')
+if len(sys.argv) != 5:
+    print(f'Usage: python3 {sys.argv[0]} <manifest file> <appstream file> <new tag> <new commit>')
     sys.exit(1)
 
-fileName = sys.argv[1]
-newTag = sys.argv[2]
-newCommit = sys.argv[3]
+manifestFile = sys.argv[1]
+appstreamFile = sys.argv[2]
+newTag = sys.argv[3]
+newCommit = sys.argv[4]
 
-# Read the given file and try to parse it to update its tag and commit.
-with open(fileName, 'r') as f:
-    config = yaml.safe_load(f)
-    success = False
+# Read the manifest file and update the tag and commit
+with open(manifestFile, 'r') as f:
+    yamlFile = yaml.safe_load(f)
+    manifestUpdateSuccess = False
     try:
-        for module in config['modules']:
+        for module in yamlFile['modules']:
             if module['name'] == 'xivlauncher':
                 for source in module['sources']:
                     if source['url'] == 'https://github.com/goatcorp/XIVLauncher.Core.git':
                         source['tag'] = newTag
                         source['commit'] = newCommit
-                        with open(fileName, 'w') as f:
-                            yaml.dump(config, f)
-                            success = True
+                        with open(manifestFile, 'w') as f:
+                            yaml.dump(yamlFile, f)
+                            manifestUpdateSuccess = True
                             break;
     except KeyError:
         pass
 
-    if success is False:
-        print('Error: failed to update XIVLauncher.Core commit and tag.. exiting')
+    if manifestUpdateSuccess is False:
+        print('Error: failed to update XIVLauncher.Core manifest.. exiting')
         sys.exit(1)
 
-    print(f'Updated XIVLauncher.Core tag to {newTag} and commit to {newCommit} in {fileName}')
+# Read the appstream file and update the tag and commit
+with open(appstreamFile, 'r') as f:
+    tree = ET.parse(f)
+    root = tree.getroot()
+    appstreamUpdateSuccess = False
+    for component in root:
+        if component.tag == 'releases':
+            for release in component:
+                release.set('date', date.today().strftime("%Y-%m-%d"))
+                release.set('version', newTag)
+                tree.write(appstreamFile)
+                appstreamUpdateSuccess = True
+                break
+    if appstreamUpdateSuccess is False:
+        print('Error: failed to update appstream file.. exiting')
+        sys.exit(1)
+
+print(f'Updated {manifestFile} and {appstreamFile} to tag {newTag} and commit {newCommit} on {date.today().strftime("%Y-%m-%d")}')

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -3,7 +3,7 @@ name: "PR XLCore to Flatpak"
 on:
   push:
     tags:
-      - "v*"
+      - "*.*.*"
 
 jobs:
   Release:

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -73,7 +73,7 @@ jobs:
           cd /tmp/xlcore-flatpak
 
           python3 -m pip install pyyaml
-          python3 update_flatpak_manifest.py dev.goats.xivlauncher.yml $(echo ${{ github.ref_name }} | sed -e "s/^v//g") ${{ github.sha }}
+          python3 update_flatpak_manifest.py dev.goats.xivlauncher.yml dev.goats.xivlauncher.appdata.xml $(echo ${{ github.ref_name }} | sed -e "s/^v//g") ${{ github.sha }}
           rm update_flatpak_manifest.py
 
           git checkout -b xlcore-${{ github.ref_name }}


### PR DESCRIPTION
Accompanies #24, this PR adds support for updating the appstream file when making a PR to FlatHub.

Example file changes:
https://github.com/BitsOfAByte/dev.goats.xivlauncher/pull/2/files

I believe the file changes look correct, the formatting was automatically applied from Python's XML parser.