### PR TITLE
Launch without 3rd-party plugins option

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/LoginAction.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/LoginAction.cs
@@ -4,6 +4,7 @@ public enum LoginAction
 {
     Game,
     GameNoDalamud,
+    GameNoThirdparty,
     GameNoLaunch,
     Repair,
     Fake,

--- a/src/XIVLauncher.Core/Components/MainPage/LoginFrame.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/LoginFrame.cs
@@ -117,6 +117,13 @@ public class LoginFrame : Component
 
                 ImGui.Separator();
 
+                if (ImGui.MenuItem("Launch without 3rd-party plugins"))
+                {
+                    this.OnLogin?.Invoke(LoginAction.GameNoThirdparty);
+                }
+
+                ImGui.Separator();
+
                 if (ImGui.MenuItem("Patch without launching"))
                 {
                     this.OnLogin?.Invoke(LoginAction.GameNoLaunch);

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -373,7 +373,7 @@ public class MainPage : Page
 
             try
             {
-                using var process = await StartGameAndAddon(loginResult, isSteam, action == LoginAction.GameNoDalamud, false).ConfigureAwait(false);
+                using var process = await StartGameAndAddon(loginResult, isSteam, action == LoginAction.GameNoDalamud, action == LoginAction.GameNoThirdparty).ConfigureAwait(false);
 
                 if (process is null)
                     throw new Exception("Could not obtain Process Handle");

--- a/src/XIVLauncher.Core/Components/MainPage/NewsFrame.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/NewsFrame.cs
@@ -107,7 +107,7 @@ public class NewsFrame : Component
             }
             else
             {
-                ImGui.Text("News are loading...");
+                ImGui.Text("News is loading...");
             }
 
             ImGui.PopStyleVar();


### PR DESCRIPTION
Adds the same functionality as in XIVLauncher WPF for launching the game without 3rd-party plugins enabled. Depends on https://github.com/goatcorp/FFXIVQuickLauncher/pull/1242 being merged and the submodule being updated before it will work due to a mismatch in Dalamud injector args for `Windows` and `UNIX`

(It also fixes a minor typo that might as well be fixed here)

### Preview
![image](https://user-images.githubusercontent.com/19539165/212570187-ca232c77-bff4-4f9b-8471-d700c87e5527.png)
