### PR TITLE
feat: Implement auto-start for pre- and post-game launch

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -758,6 +758,30 @@ public class MainPage : Page
         {
             throw new NotImplementedException();
         }
+        
+        if (!string.IsNullOrEmpty(Program.Config.BeforeScript))
+        {
+            Log.Information($"Running pre-game script {Program.Config.BeforeScript}");
+            var scriptProcess = runner.Run(Program.Config.BeforeScript, new FileInfo(Program.Config.BeforeScript).Directory?.FullName, "",
+                new Dictionary<string, string>(), false);
+            if (Program.Config.WaitForBeforeScript ?? false)
+            {
+                App.StartLoading("Running pre-game script...", "Please wait");
+                await (scriptProcess?.WaitForExitAsync()!).ConfigureAwait(false);
+            }
+        }
+
+        if (Environment.OSVersion.Platform == PlatformID.Unix && !string.IsNullOrEmpty(Program.Config.BeforeScriptWine))
+        {
+            Log.Information($"Running pre-game Wine script {Program.Config.BeforeScriptWine}");
+            var scriptProcess = runner.Run(Program.Config.BeforeScriptWine, new FileInfo(Program.Config.BeforeScriptWine).Directory?.FullName, "",
+                new Dictionary<string, string>(), true);
+            if (Program.Config.WaitForBeforeScriptWine ?? false)
+            {
+                App.StartLoading("Running pre-game Wine script...", "Please wait");
+                await (scriptProcess?.WaitForExitAsync()!).ConfigureAwait(false);
+            }
+        }
 
         if (!Program.IsSteamDeckHardware)
         {
@@ -816,6 +840,20 @@ public class MainPage : Page
             throw;
         }
 
+        if (!string.IsNullOrEmpty(Program.Config.AfterScript))
+        {
+            Log.Information($"Running post-game script {Program.Config.AfterScript}");
+            runner.Run(Program.Config.AfterScript, new FileInfo(Program.Config.AfterScript).Directory?.FullName, "",
+                new Dictionary<string, string>(), false);
+        }
+        
+        if (Environment.OSVersion.Platform == PlatformID.Unix && !string.IsNullOrEmpty(Program.Config.AfterScriptWine))
+        {
+            Log.Information($"Running post-game script {Program.Config.AfterScriptWine}");
+            runner.Run(Program.Config.AfterScriptWine, new FileInfo(Program.Config.AfterScriptWine).Directory?.FullName, "",
+                new Dictionary<string, string>(), true);
+        }
+        
         Log.Debug("Waiting for game to exit");
 
         await Task.Run(() => launchedProcess!.WaitForExit()).ConfigureAwait(false);

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabAutoStart.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabAutoStart.cs
@@ -1,16 +1,42 @@
+using System.Runtime.InteropServices;
 using ImGuiNET;
 
 namespace XIVLauncher.Core.Components.SettingsPage.Tabs;
 
 public class SettingsTabAutoStart : SettingsTab
 {
-    public override SettingsEntry[] Entries { get; } = new SettingsEntry[] { };
+    public override SettingsEntry[] Entries { get; } = new SettingsEntry[]
+    {
+        new SettingsEntry<string>("Pre-game script", 
+            "Set a script that should be executed before the game launches",
+            () => Program.Config.BeforeScript, s => Program.Config.BeforeScript = s),
+        new SettingsEntry<bool>("Wait for pre-game script", "Wait for the pre-game script before launching the game",
+            () => Program.Config.WaitForBeforeScript ?? false, s => Program.Config.WaitForBeforeScript = s),
+        new SettingsEntry<string>("Pre-game Wine script", 
+            "Set a script that should be executed in the Wine prefix before the game launches",
+            () => Program.Config.BeforeScriptWine, s => Program.Config.BeforeScriptWine = s)
+        {
+            CheckVisibility = () => RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+        },
+        new SettingsEntry<bool>("Wait for pre-game Wine script", "Wait for the pre-game Wine script before launching the game",
+            () => Program.Config.WaitForBeforeScriptWine ?? false, s => Program.Config.WaitForBeforeScriptWine = s)
+        {
+            CheckVisibility = () => RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+        },
+        new SettingsEntry<string>("Post-game script", 
+            "Set a script that should be executed after the game has launched",
+            () => Program.Config.AfterScript, s => Program.Config.AfterScript = s),
+        new SettingsEntry<string>("Post-game Wine script",
+            "Set a script that should be executed in the Wine prefix after the game has launched",
+            () => Program.Config.AfterScriptWine, s => Program.Config.AfterScriptWine = s)
+        {
+            CheckVisibility = () => RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+        }
+    };
     public override string Title => "Auto-Start";
 
     public override void Draw()
     {
-        ImGui.Text("Please check back later.");
-
         base.Draw();
     }
 }

--- a/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
+++ b/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
@@ -89,4 +89,20 @@ public interface ILauncherConfig
     public int DalamudLoadDelay { get; set; }
 
     #endregion
+
+    #region Auto-Start
+
+    public string? BeforeScript { get; set; }
+    
+    public bool? WaitForBeforeScript { get; set; }
+    
+    public string? BeforeScriptWine { get; set; }
+    
+    public bool? WaitForBeforeScriptWine { get; set; }
+    
+    public string? AfterScript { get; set; }
+    
+    public string? AfterScriptWine { get; set; }
+
+    #endregion
 }

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -115,6 +115,13 @@ class Program
         Config.WineStartupType ??= WineStartupType.Managed;
         Config.WineBinaryPath ??= "/usr/bin";
         Config.WineDebugVars ??= "-all";
+
+        Config.BeforeScript ??= "";
+        Config.BeforeScriptWine ??= "";
+        Config.WaitForBeforeScript ??= false;
+        Config.WaitForBeforeScriptWine ??= false;
+        Config.AfterScript ??= "";
+        Config.AfterScriptWine ??= "";
     }
 
     public const uint STEAM_APP_ID = 39210;


### PR DESCRIPTION
This PR implements the autostart tab with options to run a script

* on the host before the game launches
* in the Wine prefix before the game launches (only on Unix)
* on the host after the game has successfully launched and the addons were loaded
* in the Wine prefix after the game has successfully launched and the addons were loaded

This PR relies on [this PR on FFXIVQuickLauncher](https://github.com/goatcorp/FFXIVQuickLauncher/pull/1257) and cannot run without it.

The pre-game launch scripts additionally have the option to be waited on before the game launches.

An example use-case for this PR would be running either ACT or IINACT, either before or after the game has started.

An additional idea would be for a post-game script which executes after the game process has exited for cleaning up.

A screenshot of the tab:

![image](https://user-images.githubusercontent.com/1332113/215075174-6575e317-54b9-4d4b-ab99-b5141988d3b9.png)
