### PR TITLE
Add troubleshoot options

### DIFF
--- a/src/XIVLauncher.Core/Components/FtsPage.cs
+++ b/src/XIVLauncher.Core/Components/FtsPage.cs
@@ -20,6 +20,7 @@ public class FtsPage : Page
     public void OpenFtsIfNeeded()
     {
         if (CoreEnvironmentSettings.IsDeckFirstRun.HasValue)
+        {
             if (CoreEnvironmentSettings.IsDeckFirstRun.Value)
             {
                 App.State = LauncherApp.LauncherState.Fts;
@@ -27,6 +28,8 @@ public class FtsPage : Page
             }
             else
                 return;
+        }
+        
         if (!(App.Settings.CompletedFts ?? false) && Program.IsSteamDeckHardware)
         {
             App.State = LauncherApp.LauncherState.Fts;

--- a/src/XIVLauncher.Core/Components/FtsPage.cs
+++ b/src/XIVLauncher.Core/Components/FtsPage.cs
@@ -19,6 +19,14 @@ public class FtsPage : Page
 
     public void OpenFtsIfNeeded()
     {
+        if (CoreEnvironmentSettings.IsDeckFirstRun.HasValue)
+            if (CoreEnvironmentSettings.IsDeckFirstRun.Value)
+            {
+                App.State = LauncherApp.LauncherState.Fts;
+                return;
+            }
+            else
+                return;
         if (!(App.Settings.CompletedFts ?? false) && Program.IsSteamDeckHardware)
         {
             App.State = LauncherApp.LauncherState.Fts;

--- a/src/XIVLauncher.Core/Components/SettingsPage/SettingsPage.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/SettingsPage.cs
@@ -15,6 +15,7 @@ public class SettingsPage : Page
         new SettingsTabAutoStart(),
         new SettingsTabAbout(),
         new SettingsTabDebug(),
+        new SettingsTabTroubleshooting(),
     };
 
     private string searchInput = string.Empty;

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabAbout.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabAbout.cs
@@ -52,6 +52,12 @@ public class SettingsTabAbout : SettingsTab
             PlatformHelpers.OpenBrowser(Path.Combine(AppContext.BaseDirectory, "license.txt"));
         }
 
+        if (ImGui.Button("Generate Troubleshooting Pack"))
+        {
+            PackGenerator.SavePack(Program.storage);
+            PlatformHelpers.OpenBrowser(Program.storage.GetFolder("logs").FullName);
+        }
+
         ImGui.Dummy(new Vector2(20));
 
         ImGui.Image(this.logoTexture.ImGuiHandle, new Vector2(256) * ImGuiHelpers.GlobalScale);

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabAbout.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabAbout.cs
@@ -52,12 +52,6 @@ public class SettingsTabAbout : SettingsTab
             PlatformHelpers.OpenBrowser(Path.Combine(AppContext.BaseDirectory, "license.txt"));
         }
 
-        if (ImGui.Button("Generate Troubleshooting Pack"))
-        {
-            PackGenerator.SavePack(Program.storage);
-            PlatformHelpers.OpenBrowser(Program.storage.GetFolder("logs").FullName);
-        }
-
         ImGui.Dummy(new Vector2(20));
 
         ImGui.Image(this.logoTexture.ImGuiHandle, new Vector2(256) * ImGuiHelpers.GlobalScale);

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
@@ -38,6 +38,7 @@ public class SettingsTabGame : SettingsTab
         new SettingsEntry<DpiAwareness>("Game DPI Awareness", "Select the game's DPI Awareness. Change this if the game's scaling looks wrong.", () => Program.Config.DpiAwareness ?? DpiAwareness.Unaware, x => Program.Config.DpiAwareness = x),
         new SettingsEntry<bool>("Free trial account", "Check this if you are using a free trial account.", () => Program.Config.IsFt ?? false, x => Program.Config.IsFt = x),
         new SettingsEntry<bool>("Use XIVLauncher authenticator/OTP macros", "Check this if you want to use the XIVLauncher authenticator app or macros.", () => Program.Config.IsOtpServer ?? false, x => Program.Config.IsOtpServer = x),
+        new SettingsEntry<bool>("Ignore Steam", "Check this if you do not want XIVLauncher to communicate with Steam (Requires Restart).", () => Program.Config.IsIgnoringSteam ?? false, x => Program.Config.IsIgnoringSteam = x),
     };
 
     public override string Title => "Game";

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
@@ -33,12 +33,11 @@ public class SettingsTabGame : SettingsTab
             CheckWarning = x => !x ? "DirectX 9 is no longer supported by the game or Dalamud. Things may not work." : null
         },
 
-        new SettingsEntry<string>("Additional Arguments", "Additional args to start the game with", () => Program.Config.AdditionalArgs, x => Program.Config.AdditionalArgs = x),
+        new SettingsEntry<string>("Additional Arguments", "Follows Steam conventions: VAR1=value VAR2=value %command% -arg1 -arg2.\nCan't pass programs (like gamescope -- %command%). Does not accept flatpak args (--parent-pid=1, etc.)", () => Program.Config.AdditionalArgs, x => Program.Config.AdditionalArgs = x),
         new SettingsEntry<ClientLanguage>("Game Language", "Select the game's language.", () => Program.Config.ClientLanguage ?? ClientLanguage.English, x => Program.Config.ClientLanguage = x),
         new SettingsEntry<DpiAwareness>("Game DPI Awareness", "Select the game's DPI Awareness. Change this if the game's scaling looks wrong.", () => Program.Config.DpiAwareness ?? DpiAwareness.Unaware, x => Program.Config.DpiAwareness = x),
         new SettingsEntry<bool>("Free trial account", "Check this if you are using a free trial account.", () => Program.Config.IsFt ?? false, x => Program.Config.IsFt = x),
         new SettingsEntry<bool>("Use XIVLauncher authenticator/OTP macros", "Check this if you want to use the XIVLauncher authenticator app or macros.", () => Program.Config.IsOtpServer ?? false, x => Program.Config.IsOtpServer = x),
-        new SettingsEntry<bool>("Ignore Steam", "Check this if you do not want XIVLauncher to communicate with Steam (Requires Restart).", () => Program.Config.IsIgnoringSteam ?? false, x => Program.Config.IsIgnoringSteam = x),
     };
 
     public override string Title => "Game";

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
@@ -1,0 +1,56 @@
+using System.Diagnostics;
+using System.Numerics;
+using ImGuiNET;
+using XIVLauncher.Common.Unix.Compatibility;
+using XIVLauncher.Common.Util;
+using XIVLauncher.Core.Support;
+
+namespace XIVLauncher.Core.Components.SettingsPage.Tabs;
+
+public class SettingsTabTroubleshooting : SettingsTab
+{
+    public override SettingsEntry[] Entries => Array.Empty<SettingsEntry>();
+    public override string Title => "Troubleshooting";
+
+    public override void Draw()
+    {
+        ImGui.Text("\nClear the Wine Prefix - delete the ~/.xlcore/wineprefix folder");
+        if (ImGui.Button("Clear Prefix"))
+        {
+            Program.ClearPrefix();
+        }
+
+        ImGui.Text("\n\nClear the managed Wine install and DXVK");
+        if (ImGui.Button("Clear Wine & DXVK"))
+        {
+            Program.ClearTools();
+        }
+
+        ImGui.Text("\n\nClear all the files and folders related to Dalamud. Your settings will not be touched,\nbut all your plugins will be uninstalled, including 3rd-party repos.");
+        if (ImGui.Button("Clear Dalamud"))
+        {
+            Program.ClearPlugins(true);
+        }
+
+        ImGui.Text("\n\nClear all the log files.");
+        if (ImGui.Button("Clear Logs"))
+        {
+            Program.ClearLogs();
+        }
+
+        ImGui.Text("\n\nDo all of the above.");
+        if (ImGui.Button("Clear Everything"))
+        {
+            Program.ClearAll();
+        }
+
+        ImGui.Text("\n\nGenerate a troubleshooting pack to upload to the official Discord channel");
+        if (ImGui.Button("Generate tspack"))
+        {
+            PackGenerator.SavePack(Program.storage);
+            PlatformHelpers.OpenBrowser(Program.storage.GetFolder("logs").FullName);
+        }
+
+        base.Draw();
+    }
+}

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
@@ -4,6 +4,7 @@ using ImGuiNET;
 using XIVLauncher.Common.Unix.Compatibility;
 using XIVLauncher.Common.Util;
 using XIVLauncher.Core.Support;
+using XIVLauncher.Core;
 
 namespace XIVLauncher.Core.Components.SettingsPage.Tabs;
 
@@ -12,39 +13,47 @@ public class SettingsTabTroubleshooting : SettingsTab
     public override SettingsEntry[] Entries => Array.Empty<SettingsEntry>();
     public override string Title => "Troubleshooting";
 
+    private SettingsPage parentPage;
+
     public override void Draw()
     {
+        ImGui.Text("\nReset settings to default.");
+        if (ImGui.Button("Clear Settings"))
+        {
+            Program.ClearSettings(true);
+        }        
+
         ImGui.Text("\nClear the Wine Prefix - delete the ~/.xlcore/wineprefix folder");
         if (ImGui.Button("Clear Prefix"))
         {
             Program.ClearPrefix();
         }
 
-        ImGui.Text("\n\nClear the managed Wine install and DXVK");
+        ImGui.Text("\nClear the managed Wine install and DXVK");
         if (ImGui.Button("Clear Wine & DXVK"))
         {
-            Program.ClearTools();
+            Program.ClearTools(true);
         }
 
-        ImGui.Text("\n\nClear all the files and folders related to Dalamud. Your settings will not be touched,\nbut all your plugins will be uninstalled, including 3rd-party repos.");
+        ImGui.Text("\nClear all the files and folders related to Dalamud. Your settings will not be touched,\nbut all your plugins will be uninstalled, including 3rd-party repos.");
         if (ImGui.Button("Clear Dalamud"))
         {
             Program.ClearPlugins(true);
         }
 
-        ImGui.Text("\n\nClear all the log files.");
+        ImGui.Text("\nClear all the log files.");
         if (ImGui.Button("Clear Logs"))
         {
             Program.ClearLogs();
         }
 
-        ImGui.Text("\n\nDo all of the above.");
+        ImGui.Text("\nDo all of the above.");
         if (ImGui.Button("Clear Everything"))
         {
-            Program.ClearAll();
+            Program.ClearAll(true);
         }
 
-        ImGui.Text("\n\nGenerate a troubleshooting pack to upload to the official Discord channel");
+        ImGui.Text("\nGenerate a troubleshooting pack to upload to the official Discord channel");
         if (ImGui.Button("Generate tspack"))
         {
             PackGenerator.SavePack(Program.storage);

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
@@ -14,7 +14,6 @@ public class SettingsTabTroubleshooting : SettingsTab
     {
         new SettingsEntry<bool>("Hack: Disable gameoverlayrenderer.so", "Fixes some stuttering issues after 40+ minutes, but may affect steam overlay and input.", () => Program.Config.FixLDP ?? false, x => Program.Config.FixLDP = x),
         new SettingsEntry<bool>("Hack: XMODIFIERS=\"@im=null\"", "Fixes some mouse-related issues, some stuttering issues", () => Program.Config.FixIM ?? false, x => Program.Config.FixIM = x),
-        new SettingsEntry<bool>("Ignore Steam", "Check this if you do not want XIVLauncher to communicate with Steam (Requires Restart).", () => Program.Config.IsIgnoringSteam ?? false, x => Program.Config.IsIgnoringSteam = x),
     };
     public override string Title => "Troubleshooting";
 

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
@@ -44,7 +44,7 @@ public class SettingsTabTroubleshooting : SettingsTab
         ImGui.Text("\nClear all the log files.");
         if (ImGui.Button("Clear Logs"))
         {
-            Program.ClearLogs();
+            Program.ClearLogs(true);
         }
 
         ImGui.Text("\nDo all of the above.");

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
@@ -10,13 +10,22 @@ namespace XIVLauncher.Core.Components.SettingsPage.Tabs;
 
 public class SettingsTabTroubleshooting : SettingsTab
 {
-    public override SettingsEntry[] Entries => Array.Empty<SettingsEntry>();
+    public override SettingsEntry[] Entries { get; } =
+    {
+        new SettingsEntry<bool>("Hack: Disable gameoverlayrenderer.so", "Fixes some stuttering issues after 40+ minutes, but may affect steam overlay and input.", () => Program.Config.FixLDP ?? false, x => Program.Config.FixLDP = x),
+        new SettingsEntry<bool>("Hack: XMODIFIERS=\"@im=null\"", "Fixes some mouse-related issues, some stuttering issues", () => Program.Config.FixIM ?? false, x => Program.Config.FixIM = x),
+        new SettingsEntry<bool>("Ignore Steam", "Check this if you do not want XIVLauncher to communicate with Steam (Requires Restart).", () => Program.Config.IsIgnoringSteam ?? false, x => Program.Config.IsIgnoringSteam = x),
+    };
     public override string Title => "Troubleshooting";
 
     private SettingsPage parentPage;
 
     public override void Draw()
     {
+        base.Draw();
+
+        ImGui.Separator();
+
         ImGui.Text("\nReset settings to default.");
         if (ImGui.Button("Clear Settings"))
         {
@@ -59,7 +68,5 @@ public class SettingsTabTroubleshooting : SettingsTab
             PackGenerator.SavePack(Program.storage);
             PlatformHelpers.OpenBrowser(Program.storage.GetFolder("logs").FullName);
         }
-
-        base.Draw();
     }
 }

--- a/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
+++ b/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
@@ -78,6 +78,10 @@ public interface ILauncherConfig
 
     public string? WineDebugVars { get; set; }
 
+    public bool? FixLDP { get; set; }
+
+    public bool? FixIM { get; set; }
+
     #endregion
 
     #region Dalamud

--- a/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
+++ b/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
@@ -10,7 +10,8 @@ public static class CoreEnvironmentSettings
     public static bool ClearPrefix => CheckEnvBool("XLC_CLEAR_PREFIX");
     public static bool ClearPlugins => CheckEnvBool("XLC_CLEAR_PLUGINS");
     public static bool ClearTools => CheckEnvBool("XLC_CLEAR_TOOLS");
-    public static bool ClearAll => CheckEnvBool("XLC_NUKE");
+    public static bool ClearLogs => CheckEnvBool("XLC_CLEAR_LOGS");
+    public static bool ClearAll => CheckEnvBool("XLC_CLEAR_ALL");
     public static bool? UseSteam => CheckEnvBoolOrNull("XLC_USE_STEAM"); // Fix for Steam Deck users who lock themselves out
 
     private static bool CheckEnvBool(string key)

--- a/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
+++ b/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
@@ -1,0 +1,29 @@
+namespace XIVLauncher.Core;
+
+public static class CoreEnvironmentSettings
+{
+    public static bool? IsDeck => CheckEnvBoolOrNull("XLC_DECK");
+    public static bool? IsDeckGameMode => CheckEnvBoolOrNull("XLC_GAMEMODE");
+    public static bool? IsDeckFirstRun => CheckEnvBoolOrNull("XLC_FIRSTRUN");
+    public static bool IsUpgrade => CheckEnvBool("XLC_SHOW_UPGRADE");
+    public static bool ClearSettings => CheckEnvBool("XLC_CLEAR_SETTINGS");
+    public static bool ClearPrefix => CheckEnvBool("XLC_CLEAR_PREFIX");
+    public static bool ClearPlugins => CheckEnvBool("XLC_CLEAR_PLUGINS");
+    public static bool ClearTools => CheckEnvBool("XLC_CLEAR_TOOLS");
+    public static bool ClearAll => CheckEnvBool("XLC_NUKE");
+
+    private static bool CheckEnvBool(string key)
+    {
+        string val = (System.Environment.GetEnvironmentVariable(key) ?? string.Empty).ToLower();
+        if (val == "1" || val == "true" || val == "yes" || val == "y" || val == "on") return true;
+        return false;
+    }
+
+    private static bool? CheckEnvBoolOrNull(string key)
+    {
+        string val = (System.Environment.GetEnvironmentVariable(key) ?? string.Empty).ToLower();
+        if (val == "1" || val == "true" || val == "yes" || val == "y" || val == "on") return true;
+        if (val == "0" || val == "false" || val == "no" || val == "n" || val == "off") return false;
+        return null;
+    }
+}

--- a/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
+++ b/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
@@ -11,6 +11,7 @@ public static class CoreEnvironmentSettings
     public static bool ClearPlugins => CheckEnvBool("XLC_CLEAR_PLUGINS");
     public static bool ClearTools => CheckEnvBool("XLC_CLEAR_TOOLS");
     public static bool ClearAll => CheckEnvBool("XLC_NUKE");
+    public static bool? UseSteam => CheckEnvBoolOrNull("XLC_USE_STEAM"); // Fix for Steam Deck users who lock themselves out
 
     private static bool CheckEnvBool(string key)
     {

--- a/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
+++ b/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
@@ -1,18 +1,20 @@
+using System;
+
 namespace XIVLauncher.Core;
 
 public static class CoreEnvironmentSettings
 {
-    public static bool? IsDeck => CheckEnvBoolOrNull("XLC_DECK");
-    public static bool? IsDeckGameMode => CheckEnvBoolOrNull("XLC_GAMEMODE");
-    public static bool? IsDeckFirstRun => CheckEnvBoolOrNull("XLC_FIRSTRUN");
-    public static bool IsUpgrade => CheckEnvBool("XLC_SHOW_UPGRADE");
-    public static bool ClearSettings => CheckEnvBool("XLC_CLEAR_SETTINGS");
-    public static bool ClearPrefix => CheckEnvBool("XLC_CLEAR_PREFIX");
-    public static bool ClearPlugins => CheckEnvBool("XLC_CLEAR_PLUGINS");
-    public static bool ClearTools => CheckEnvBool("XLC_CLEAR_TOOLS");
-    public static bool ClearLogs => CheckEnvBool("XLC_CLEAR_LOGS");
-    public static bool ClearAll => CheckEnvBool("XLC_CLEAR_ALL");
-    public static bool? UseSteam => CheckEnvBoolOrNull("XLC_USE_STEAM"); // Fix for Steam Deck users who lock themselves out
+    public static bool? IsDeck => CheckEnvBoolOrNull("XL_DECK");
+    public static bool? IsDeckGameMode => CheckEnvBoolOrNull("XL_GAMEMODE");
+    public static bool? IsDeckFirstRun => CheckEnvBoolOrNull("XL_FIRSTRUN");
+    public static bool IsUpgrade => CheckEnvBool("XL_SHOW_UPGRADE");
+    public static bool ClearSettings => CheckEnvBool("XL_CLEAR_SETTINGS");
+    public static bool ClearPrefix => CheckEnvBool("XL_CLEAR_PREFIX");
+    public static bool ClearPlugins => CheckEnvBool("XL_CLEAR_PLUGINS");
+    public static bool ClearTools => CheckEnvBool("XL_CLEAR_TOOLS");
+    public static bool ClearLogs => CheckEnvBool("XL_CLEAR_LOGS");
+    public static bool ClearAll => CheckEnvBool("XL_CLEAR_ALL");
+    public static bool? UseSteam => CheckEnvBoolOrNull("XL_USE_STEAM"); // Fix for Steam Deck users who lock themselves out
 
     private static bool CheckEnvBool(string key)
     {
@@ -27,5 +29,12 @@ public static class CoreEnvironmentSettings
         if (val == "1" || val == "true" || val == "yes" || val == "y" || val == "on") return true;
         if (val == "0" || val == "false" || val == "no" || val == "n" || val == "off") return false;
         return null;
+    }
+
+    public static string GetCleanEnvironmentVariable(string envvar, string badstring = "", string separator = ":")
+    {
+        string dirty = Environment.GetEnvironmentVariable(envvar) ?? "";
+        if (badstring.Equals("")) return dirty;
+        return string.Join(separator, Array.FindAll<string>(dirty.Split(separator, StringSplitOptions.RemoveEmptyEntries), s => !s.Contains(badstring)));
     }
 }

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -49,8 +49,12 @@ class Program
     public static DirectoryInfo DotnetRuntime => storage.GetFolder("runtime");
 
     // TODO: We don't have the steamworks api for this yet.
-    public static bool IsSteamDeckHardware => Directory.Exists("/home/deck");
-    public static bool IsSteamDeckGamingMode => Steam != null && Steam.IsValid && Steam.IsRunningOnSteamDeck();
+    public static bool IsSteamDeckHardware => CoreEnvironmentSettings.IsDeck.HasValue ?
+        CoreEnvironmentSettings.IsDeck.Value :
+        Directory.Exists("/home/deck") || (CoreEnvironmentSettings.IsDeckGameMode ?? false) || (CoreEnvironmentSettings.IsDeckFirstRun ?? false);
+    public static bool IsSteamDeckGamingMode => CoreEnvironmentSettings.IsDeckGameMode.HasValue ?
+        CoreEnvironmentSettings.IsDeckGameMode.Value :
+        Steam != null && Steam.IsValid && Steam.IsRunningOnSteamDeck();
 
     private const string APP_NAME = "xlcore";
 
@@ -214,6 +218,8 @@ class Program
                 needUpdate = versionCheckResult.NeedUpdate;
         }   
 #endif
+
+        needUpdate = CoreEnvironmentSettings.IsUpgrade ? true : needUpdate;
 
         launcherApp = new LauncherApp(storage, needUpdate);
 

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -373,9 +373,10 @@ class Program
     public static void ClearPrefix()
     {
         storage.GetFolder("wineprefix").Delete(true);
+        storage.GetFolder("wineprefix");
     }
 
-    public static void ClearPlugins()
+    public static void ClearPlugins(bool tsbutton = false)
     {
         storage.GetFolder("dalamud").Delete(true);
         storage.GetFolder("dalamudAssets").Delete(true);
@@ -383,16 +384,32 @@ class Program
         storage.GetFolder("runtime").Delete(true);
         if (storage.GetFile("dalamudUI.ini").Exists) storage.GetFile("dalamudUI.ini").Delete();
         if (storage.GetFile("dalamudConfig.json").Exists) storage.GetFile("dalamudConfig.json").Delete();
+        storage.GetFolder("dalamud");
+        storage.GetFolder("dalamudAssets");
+        storage.GetFolder("installedPlugins");
+        storage.GetFolder("runtime");
+        if (tsbutton)
+        {
+            DalamudLoadInfo = new DalamudOverlayInfoProxy();
+            DalamudUpdater = new DalamudUpdater(storage.GetFolder("dalamud"), storage.GetFolder("runtime"), storage.GetFolder("dalamudAssets"), storage.Root, null, null)
+            {
+                Overlay = DalamudLoadInfo
+            };
+            DalamudUpdater.Run();
+        }
     }
 
     public static void ClearTools()
     {
         storage.GetFolder("compatibilitytool").Delete(true);
+        storage.GetFolder("compatibilitytool/beta");
+        storage.GetFolder("compatibilitytool/dxvk");
     }
 
     public static void ClearLogs()
     {
         storage.GetFolder("logs").Delete(true);
+        storage.GetFolder("logs");
         string[] logfiles = { "dalamud.boot.log", "dalamud.boot.old.log", "dalamud.log", "dalamud.injector.log"};
         foreach (string logfile in logfiles)
             if (storage.GetFile(logfile).Exists) storage.GetFile(logfile).Delete();

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -99,9 +99,9 @@ class Program
 
         Config.IsDx11 ??= true;
         Config.IsEncryptArgs ??= true;
-        Config.IsFt ??= false;
+        Config.IsFt ??= true; // Default should be true, for Steam Deck users following the guide.
         Config.IsOtpServer ??= false;
-        Config.IsIgnoringSteam ??= false;
+        Config.IsIgnoringSteam = CoreEnvironmentSettings.UseSteam.HasValue ? !CoreEnvironmentSettings.UseSteam.Value : Config.IsIgnoringSteam ?? false;
 
         Config.PatchPath ??= storage.GetFolder("patch");
         Config.PatchAcquisitionMethod ??= AcquisitionMethod.Aria;
@@ -149,23 +149,43 @@ class Program
                 default:
                     throw new PlatformNotSupportedException();
             }
-            if (!Config.IsIgnoringSteam ?? true)
+            if (!Config.IsIgnoringSteam.Value)
             {
+                uint appId, altId;
+                string xiv1, xiv2;
+                if (Config.IsFt.Value)
+                {
+                    appId = STEAM_APP_ID_FT;
+                    altId = STEAM_APP_ID;
+                    xiv1 = "free trial";
+                    xiv2 = "full version";
+                }
+                else
+                {
+                    appId = STEAM_APP_ID;
+                    altId = STEAM_APP_ID_FT;
+                    xiv1 = "full version";
+                    xiv2 = "free trial";
+                }
                 try
                 {
-                    var appId = Config.IsFt == true ? STEAM_APP_ID_FT : STEAM_APP_ID;
+                    Log.Information($"Steam: Trying to load the {xiv1} of FFXIV");
                     Steam.Initialize(appId);
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "Couldn't init Steam with game AppIds, trying FT");
-                    Steam.Initialize(STEAM_APP_ID_FT);
+                    Log.Error(ex, $"Steam: Couldn't load the {xiv1} of FFXIV, now trying the {xiv2}.");
+                    Steam.Initialize(altId);
                 }
+            }
+            else
+            {
+                Log.Information("Steam: Checks disabled. If you have a Steam service account, you might not be able to log in.");
             }
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Steam couldn't load");
+            Log.Error(ex, "Steam: Couldn't find any version of FFXIV");
         }
 
         DalamudLoadInfo = new DalamudOverlayInfoProxy();

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -170,43 +170,23 @@ class Program
                 default:
                     throw new PlatformNotSupportedException();
             }
-            if (!Config.IsIgnoringSteam.Value)
+            if (!Config.IsIgnoringSteam ?? true)
             {
-                uint appId, altId;
-                string xiv1, xiv2;
-                if (Config.IsFt.Value)
-                {
-                    appId = STEAM_APP_ID_FT;
-                    altId = STEAM_APP_ID;
-                    xiv1 = "free trial";
-                    xiv2 = "full version";
-                }
-                else
-                {
-                    appId = STEAM_APP_ID;
-                    altId = STEAM_APP_ID_FT;
-                    xiv1 = "full version";
-                    xiv2 = "free trial";
-                }
                 try
                 {
-                    Log.Information($"Steam: Trying to load the {xiv1} of FFXIV");
+                    var appId = Config.IsFt == true ? STEAM_APP_ID_FT : STEAM_APP_ID;
                     Steam.Initialize(appId);
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, $"Steam: Couldn't load the {xiv1} of FFXIV, now trying the {xiv2}.");
-                    Steam.Initialize(altId);
+                    Log.Error(ex, "Couldn't init Steam with game AppIds, trying FT");
+                    Steam.Initialize(STEAM_APP_ID_FT);
                 }
-            }
-            else
-            {
-                Log.Information("Steam: Checks disabled. If you have a Steam service account, you might not be able to log in.");
             }
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Steam: Couldn't find any version of FFXIV");
+            Log.Error(ex, "Steam couldn't load");
         }
 
         DalamudLoadInfo = new DalamudOverlayInfoProxy();

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using System.IO;
 using CheapLoc;
 using Config.Net;
 using ImGuiNET;
@@ -127,6 +128,20 @@ class Program
     private static void Main(string[] args)
     {
         storage = new Storage(APP_NAME);
+
+        if (CoreEnvironmentSettings.ClearAll)
+        {
+            ClearAll();
+        }
+        else
+        {
+            if (CoreEnvironmentSettings.ClearSettings) ClearSettings();
+            if (CoreEnvironmentSettings.ClearPrefix) ClearPrefix();
+            if (CoreEnvironmentSettings.ClearPlugins) ClearPlugins();
+            if (CoreEnvironmentSettings.ClearTools) ClearTools();
+            if (CoreEnvironmentSettings.ClearLogs) ClearLogs();
+        }
+        
         SetupLogging(args);
         LoadConfig(storage);
 
@@ -348,5 +363,47 @@ class Program
             default:
                 throw new ArgumentException($"Invalid secret provider: {envVar}");
         }
+    }
+
+    public static void ClearSettings()
+    {
+        if (storage.GetFile("launcher.ini").Exists) storage.GetFile("launcher.ini").Delete();
+    }
+
+    public static void ClearPrefix()
+    {
+        storage.GetFolder("wineprefix").Delete(true);
+    }
+
+    public static void ClearPlugins()
+    {
+        storage.GetFolder("dalamud").Delete(true);
+        storage.GetFolder("dalamudAssets").Delete(true);
+        storage.GetFolder("installedPlugins").Delete(true);
+        storage.GetFolder("runtime").Delete(true);
+        if (storage.GetFile("dalamudUI.ini").Exists) storage.GetFile("dalamudUI.ini").Delete();
+        if (storage.GetFile("dalamudConfig.json").Exists) storage.GetFile("dalamudConfig.json").Delete();
+    }
+
+    public static void ClearTools()
+    {
+        storage.GetFolder("compatibilitytool").Delete(true);
+    }
+
+    public static void ClearLogs()
+    {
+        storage.GetFolder("logs").Delete(true);
+        string[] logfiles = { "dalamud.boot.log", "dalamud.boot.old.log", "dalamud.log", "dalamud.injector.log"};
+        foreach (string logfile in logfiles)
+            if (storage.GetFile(logfile).Exists) storage.GetFile(logfile).Delete();
+    }
+
+    public static void ClearAll()
+    {
+        ClearSettings();
+        ClearPrefix();
+        ClearPlugins();
+        ClearTools();
+        ClearLogs();
     }
 }

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -122,6 +122,9 @@ class Program
         Config.WineStartupType ??= WineStartupType.Managed;
         Config.WineBinaryPath ??= "/usr/bin";
         Config.WineDebugVars ??= "-all";
+
+        Config.FixLDP ??= false;
+        Config.FixIM ??= false;
     }
 
     public const uint STEAM_APP_ID = 39210;

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -365,9 +365,14 @@ class Program
         }
     }
 
-    public static void ClearSettings()
+    public static void ClearSettings(bool tsbutton = false)
     {
         if (storage.GetFile("launcher.ini").Exists) storage.GetFile("launcher.ini").Delete();
+        if (tsbutton)
+        {
+            LoadConfig(storage);
+            launcherApp.State = LauncherApp.LauncherState.Settings;
+        }
     }
 
     public static void ClearPrefix()
@@ -399,11 +404,12 @@ class Program
         }
     }
 
-    public static void ClearTools()
+    public static void ClearTools(bool tsbutton = false)
     {
         storage.GetFolder("compatibilitytool").Delete(true);
         storage.GetFolder("compatibilitytool/beta");
         storage.GetFolder("compatibilitytool/dxvk");
+        if (tsbutton) CreateCompatToolsInstance();
     }
 
     public static void ClearLogs()
@@ -415,12 +421,12 @@ class Program
             if (storage.GetFile(logfile).Exists) storage.GetFile(logfile).Delete();
     }
 
-    public static void ClearAll()
+    public static void ClearAll(bool tsbutton = false)
     {
-        ClearSettings();
+        ClearSettings(tsbutton);
         ClearPrefix();
-        ClearPlugins();
-        ClearTools();
+        ClearPlugins(tsbutton);
+        ClearTools(tsbutton);
         ClearLogs();
     }
 }

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -59,6 +59,8 @@ class Program
 
     private const string APP_NAME = "xlcore";
 
+    private static string[] mainargs;
+
     private static uint invalidationFrames = 0;
     private static Vector2 lastMousePosition;
 
@@ -100,7 +102,7 @@ class Program
 
         Config.IsDx11 ??= true;
         Config.IsEncryptArgs ??= true;
-        Config.IsFt ??= true; // Default should be true, for Steam Deck users following the guide.
+        Config.IsFt ??= false;
         Config.IsOtpServer ??= false;
         Config.IsIgnoringSteam = CoreEnvironmentSettings.UseSteam.HasValue ? !CoreEnvironmentSettings.UseSteam.Value : Config.IsIgnoringSteam ?? false;
 
@@ -127,6 +129,7 @@ class Program
 
     private static void Main(string[] args)
     {
+        mainargs = args;
         storage = new Storage(APP_NAME);
 
         if (CoreEnvironmentSettings.ClearAll)
@@ -142,7 +145,7 @@ class Program
             if (CoreEnvironmentSettings.ClearLogs) ClearLogs();
         }
         
-        SetupLogging(args);
+        SetupLogging(mainargs);
         LoadConfig(storage);
 
         Secrets = GetSecretProvider(storage);
@@ -412,13 +415,16 @@ class Program
         if (tsbutton) CreateCompatToolsInstance();
     }
 
-    public static void ClearLogs()
+    public static void ClearLogs(bool tsbutton = false)
     {
         storage.GetFolder("logs").Delete(true);
         storage.GetFolder("logs");
         string[] logfiles = { "dalamud.boot.log", "dalamud.boot.old.log", "dalamud.log", "dalamud.injector.log"};
         foreach (string logfile in logfiles)
             if (storage.GetFile(logfile).Exists) storage.GetFile(logfile).Delete();
+        if (tsbutton)
+            SetupLogging(mainargs);
+        
     }
 
     public static void ClearAll(bool tsbutton = false)
@@ -427,6 +433,6 @@ class Program
         ClearPrefix();
         ClearPlugins(tsbutton);
         ClearTools(tsbutton);
-        ClearLogs();
+        ClearLogs(true);
     }
 }


### PR DESCRIPTION
This patch adds a few features specifically to help troubleshooting for steam deck users or inexperienced linux users.

1. Adds a bunch of environment variables to force different states or clear parts of the .xlcore folder. All of these begin with XLC instead of XL to make them specific to XL.Core. Valid true values are true, yes, y, on, and 1. Valid false values (where relevant) are false, no, n, off, and 0. Anything else will evaluate as unset.

2. Adds a troubleshooting tab to settings. This contains some buttons to clear the compatibilitytools, wineprefix, dalamud folders, and logs. There's also a button to reset settings to default, and one more to do all of these at once. After files and folders are deleted, some will be immediately reinitialized so that the launcher doesn't have to be restarted. Finally, the "Generate tspack" button has been moved to this tab.

3. Improves the Additional Arguments field. Now it understands environment variables. It uses the same format as Steam, just to make it easy. So, for example, you could do `MANGOHUD=1 %command%` to enable MangoHud. It doesn't work with external programs, unlike steam.

New deck environment vars are as follows:

- XL_DECK. True, false, or unset. Force XL.Core into deck mode or turn it off on the steam deck. Unset leads to default detection.
- XL_GAMEMODE. True, false, or unset. Force XL.Core to think it is in Game Mode, or that it's not. Unset leads to default detection.
- XL_FIRSTRUN.  True, false, or unset. Force XL.Core to run (or skip) the first time setup dialog. Unset leads to default behavior.
- XL_SHOW_UPGRADE. True, or unset. Force XL.Core to bring up the upgrade dialogue. Probably not useful, but it wasn't hard to get working.
- XL_USE_STEAM. True, false, or unset. This is the same as using the "Ignore Steam" option in settings, but deck users can set it in their launch options to force steam detection if they accidentally toggled it and can't interact any more.

The troubleshooting functions are also added as environment variables, just for those people who like to script or use the command line.
- XL_CLEAR_SETTINGS. True or unset. Deletes the launcher.ini file on launch. 
- XL_CLEAR_PREFIX. True or unset. Deletes the wineprefix folder.
- XL_CLEAR_PLUGINS. True or unset. Deletes the following folders: dalamud, dalamudAssets, installedPlugins, runtime. Also deletes dalamudUI.ini and dalamudConfig.json.
- XL_CLEAR_TOOLS. True or unset. Deletes the compatibilitytools folder.
- XL_CLEAR_LOGS. True or unset. Deletes the dalamud logs and the log folder.
- XL_CLEAR_ALL. True or unset. Does all of the above.

Here's a pic of the new Troubleshooting tab:
![xlcore-troubleshooting-tab](https://user-images.githubusercontent.com/109918887/232646765-a002b464-2c3e-4b01-9b74-536a6da2b8f1.png)

And here's the Game Tab, with the improved Additional Arguments feature:
![xlcore-improved-args](https://user-images.githubusercontent.com/109918887/232646898-875e142f-acc0-4af0-9f76-567ad436f46f.png)
