### PR TITLE
Add Proton as an available Wine Installation Type

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -784,7 +784,7 @@ public class MainPage : Page
         var protonProcess = launchedProcess;
         if (Program.CompatibilityTools.useProton)
         {
-            Log.Information("Launching Proton instead of Wine.");
+            Log.Information("Launching Proton runner. Proton's built-in wine will be launched as a child process.");
             var gameName = (App.Settings.IsDx11 ?? true) ? "ffxiv_dx11.exe" : "ffxiv.exe";
             var unixPid = Program.CompatibilityTools.GetUnixProcessIdByName(gameName);
             launchedProcess = Process.GetProcessById(unixPid);

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -782,7 +782,7 @@ public class MainPage : Page
             App.Settings.DpiAwareness.GetValueOrDefault(DpiAwareness.Unaware));
 
         var protonProcess = launchedProcess;
-        if (Program.CompatibilityTools.useProton)
+        if (Program.CompatibilityTools.UseProton)
         {
             Log.Information("Launching Proton runner. Proton's built-in wine will be launched as a child process.");
             var gameName = (App.Settings.IsDx11 ?? true) ? "ffxiv_dx11.exe" : "ffxiv.exe";
@@ -828,6 +828,8 @@ public class MainPage : Page
 
         Log.Information("Waiting for game to exit");
 
+        // Auto-launch apps need to go here when using proton. Can't inject Dalamud properly otherwise.
+
         await Task.Run(() => launchedProcess!.WaitForExit()).ConfigureAwait(false);
 
         Log.Information("Game has exited");
@@ -846,7 +848,7 @@ public class MainPage : Page
         {
             Log.Error(ex, "Could not shut down Steam");
         }
-        if (Program.CompatibilityTools.useProton)
+        if (Program.CompatibilityTools.UseProton)
             return protonProcess!;
         return launchedProcess!;
     }

--- a/src/XIVLauncher.Core/Components/SettingsPage/DictionarySettingsEntry.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/DictionarySettingsEntry.cs
@@ -1,0 +1,70 @@
+using ImGuiNET;
+using System.Collections;
+using System.Linq;
+
+namespace XIVLauncher.Core.Components.SettingsPage;
+
+public class DictionarySettingsEntry : SettingsEntry<string>
+{
+    public Dictionary<string, string> Pairs;
+
+    public DictionarySettingsEntry(string name, string description, Dictionary<string, string> pairs, Func<string> load, Action<string> save)
+        : base(name, description, load, save)
+    { 
+        this.Pairs = pairs;
+    }
+
+
+    public override void Draw()
+    {
+        var nativeValue = this.Value;
+        string idx = (string)(this.InternalValue ?? "Proton 7.0");
+
+        ImGuiHelpers.TextWrapped(this.Name);
+
+        Dictionary<string, string>.KeyCollection keys = Pairs.Keys;
+
+        if (ImGui.BeginCombo($"###{Id.ToString()}", idx + ": " + Pairs[idx]))
+        {
+            foreach ( string key in keys )
+            {
+                if (ImGui.Selectable(key + ": " + Pairs[key], idx == key))
+                {
+                    this.InternalValue = key;
+                }
+            }
+            ImGui.EndCombo();
+        }
+
+        ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudGrey);
+        ImGuiHelpers.TextWrapped(this.Description);
+        ImGui.PopStyleColor();
+
+        if (this.CheckValidity != null)
+        {
+            var validityMsg = this.CheckValidity.Invoke(this.Value);
+            this.IsValid = string.IsNullOrEmpty(validityMsg);
+
+            if (!this.IsValid)
+            {
+                ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
+                ImGui.Text(validityMsg);
+                ImGui.PopStyleColor();
+            }
+        }
+        else
+        {
+            this.IsValid = true;
+        }
+
+        var warningMessage = this.CheckWarning?.Invoke(this.Value);
+
+        if (warningMessage != null)
+        {
+            ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
+            ImGui.Text(warningMessage);
+            ImGui.PopStyleColor();
+        }
+        
+    }
+}

--- a/src/XIVLauncher.Core/Components/SettingsPage/SettingsEntry{T}.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/SettingsEntry{T}.cs
@@ -94,7 +94,7 @@ public class SettingsEntry<T> : SettingsEntry
         }
 
         ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudGrey);
-        ImGuiHelpers.TextWrapped(this.Description);
+        if (!string.IsNullOrWhiteSpace(this.Description)) ImGuiHelpers.TextWrapped(this.Description);
         ImGui.PopStyleColor();
 
         if (this.CheckValidity != null)

--- a/src/XIVLauncher.Core/Components/SettingsPage/SettingsTab.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/SettingsTab.cs
@@ -16,11 +16,12 @@ public abstract class SettingsTab : Component
         foreach (SettingsEntry settingsEntry in Entries)
         {
             if (settingsEntry.IsVisible)
+            {
                 settingsEntry.Draw();
-
-            ImGui.Dummy(new Vector2(10) * ImGuiHelpers.GlobalScale);
+                ImGui.Dummy(new Vector2(10) * ImGuiHelpers.GlobalScale);
+            }
         }
-
+        ImGui.Dummy(new Vector2(10) * ImGuiHelpers.GlobalScale);
         base.Draw();
     }
 

--- a/src/XIVLauncher.Core/Components/SettingsPage/SettingsTab.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/SettingsTab.cs
@@ -21,7 +21,6 @@ public abstract class SettingsTab : Component
                 ImGui.Dummy(new Vector2(10) * ImGuiHelpers.GlobalScale);
             }
         }
-        ImGui.Dummy(new Vector2(10) * ImGuiHelpers.GlobalScale);
         base.Draw();
     }
 

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -23,6 +23,10 @@ public class SettingsTabWine : SettingsTab
             {
                 CheckVisibility = () => startupTypeSetting.Value == WineStartupType.Custom
             },
+            new DictionarySettingsEntry("Proton Version", "", ProtonManager.Versions, () => Program.Config.ProtonVersion, s => Program.Config.ProtonVersion = s)
+            {
+                CheckVisibility = () => startupTypeSetting.Value == WineStartupType.Proton
+            },
 
             new SettingsEntry<bool>("Enable Feral's GameMode", "Enable launching with Feral Interactive's GameMode CPU optimizations.", () => Program.Config.GameModeEnabled ?? true, b => Program.Config.GameModeEnabled = b)
             {

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -107,7 +107,7 @@ public class SettingsTabWine : SettingsTab
 
         if (ImGui.Button("Open Wine explorer (run apps in prefix)"))
         {
-            Program.CompatibilityTools.RunInPrefix("explorer");
+            Program.CompatibilityTools.RunInPrefix("explorer", inject: false);
         }
 
         if (ImGui.Button("Kill all wine processes"))

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -80,16 +80,16 @@ public class SettingsTabWine : SettingsTab
     {
         base.Draw();
 
-        if (!Program.CompatibilityTools.IsToolDownloaded || startupTypeSetting.Value == WineStartupType.Proton)
-        {
-            ImGui.BeginDisabled();
-            if (startupTypeSetting.Value == WineStartupType.Proton)
-                ImGui.Text("These options do not work properly with Proton yet.");
-            else
-                ImGui.Text("Compatibility tool isn't set up. Please start the game at least once.");
+        // if (!Program.CompatibilityTools.IsToolDownloaded || startupTypeSetting.Value == WineStartupType.Proton)
+        // {
+        //     ImGui.BeginDisabled();
+        //     if (startupTypeSetting.Value == WineStartupType.Proton)
+        //         ImGui.Text("These options do not work properly with Proton yet.");
+        //     else
+        //         ImGui.Text("Compatibility tool isn't set up. Please start the game at least once.");
 
-            ImGui.Dummy(new Vector2(10));
-        }
+        //     ImGui.Dummy(new Vector2(10));
+        // }
 
         if (ImGui.Button("Open prefix"))
         {
@@ -115,10 +115,10 @@ public class SettingsTabWine : SettingsTab
             Program.CompatibilityTools.Kill();
         }
 
-        if (!Program.CompatibilityTools.IsToolDownloaded || startupTypeSetting.Value == WineStartupType.Proton)
-        {
-            ImGui.EndDisabled();
-        }
+        // if (!Program.CompatibilityTools.IsToolDownloaded || startupTypeSetting.Value == WineStartupType.Proton)
+        // {
+        //     ImGui.EndDisabled();
+        // }
     }
 
     public override void Save()

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -20,7 +20,10 @@ public class SettingsTabWine : SettingsTab
                     CheckValidity = x =>
                     {
                         if (x == WineStartupType.Proton && !ProtonManager.IsValid())
-                            return "No proton version found! Check launcher.ini and make sure that SteamPath points your Steam root\nUsually this is /home/username/.steam/root or /home/username/.local/share/Steam";
+                        {
+                            var userHome = System.Environment.GetEnvironmentVariable("HOME") ?? "/home/username";
+                            return $"No proton version found! Check launcher.ini and make sure that SteamPath points your Steam root\nUsually this is {userHome}/.steam/root or {userHome}/.local/share/Steam";
+                        }
                         return null;
                     }
                 },
@@ -77,10 +80,13 @@ public class SettingsTabWine : SettingsTab
     {
         base.Draw();
 
-        if (!Program.CompatibilityTools.IsToolDownloaded)
+        if (!Program.CompatibilityTools.IsToolDownloaded || startupTypeSetting.Value == WineStartupType.Proton)
         {
             ImGui.BeginDisabled();
-            ImGui.Text("Compatibility tool isn't set up. Please start the game at least once.");
+            if (startupTypeSetting.Value == WineStartupType.Proton)
+                ImGui.Text("These options do not work properly with Proton yet.");
+            else
+                ImGui.Text("Compatibility tool isn't set up. Please start the game at least once.");
 
             ImGui.Dummy(new Vector2(10));
         }
@@ -109,7 +115,7 @@ public class SettingsTabWine : SettingsTab
             Program.CompatibilityTools.Kill();
         }
 
-        if (!Program.CompatibilityTools.IsToolDownloaded)
+        if (!Program.CompatibilityTools.IsToolDownloaded || startupTypeSetting.Value == WineStartupType.Proton)
         {
             ImGui.EndDisabled();
         }

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -15,7 +15,15 @@ public class SettingsTabWine : SettingsTab
         Entries = new SettingsEntry[]
         {
             startupTypeSetting = new SettingsEntry<WineStartupType>("Installation Type", "Choose how XIVLauncher will start and manage your game installation.",
-                () => Program.Config.WineStartupType ?? WineStartupType.Managed, x => Program.Config.WineStartupType = x),
+                () => Program.Config.WineStartupType ?? WineStartupType.Managed, x => Program.Config.WineStartupType = x)
+                {
+                    CheckValidity = x =>
+                    {
+                        if (x == WineStartupType.Proton && !ProtonManager.IsValid())
+                            return "No proton version found! Check launcher.ini and make sure that SteamPath points your Steam root\nUsually this is /home/username/.steam/root or /home/username/.local/share/Steam";
+                        return null;
+                    }
+                },
 
             new SettingsEntry<string>("Wine Binary Path",
                 "Set the path XIVLauncher will use to run applications via wine.\nIt should be an absolute path to a folder containing wine64 and wineserver binaries.",
@@ -25,7 +33,7 @@ public class SettingsTabWine : SettingsTab
             },
             new DictionarySettingsEntry("Proton Version", "", ProtonManager.Versions, () => Program.Config.ProtonVersion, s => Program.Config.ProtonVersion = s)
             {
-                CheckVisibility = () => startupTypeSetting.Value == WineStartupType.Proton
+                CheckVisibility = () => startupTypeSetting.Value == WineStartupType.Proton,
             },
 
             new SettingsEntry<bool>("Enable Feral's GameMode", "Enable launching with Feral Interactive's GameMode CPU optimizations.", () => Program.Config.GameModeEnabled ?? true, b => Program.Config.GameModeEnabled = b)

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -38,6 +38,14 @@ public class SettingsTabWine : SettingsTab
             {
                 CheckVisibility = () => startupTypeSetting.Value == WineStartupType.Proton,
             },
+            new SettingsEntry<bool>("Use Steam Soldier Runtime", "Use Steam's container system. Proton is designed with this in mind, but may run without it.", () => Program.Config.UseSoldier ?? true, b => Program.Config.UseSoldier = b)
+            {
+                CheckVisibility = () => startupTypeSetting.Value == WineStartupType.Proton,
+            },
+            new SettingsEntry<bool>("Use Reaper", "Use Steam's reaper process to launch the game.", () => Program.Config.UseReaper ?? false, b => Program.Config.UseReaper = b)
+            {
+                CheckVisibility = () => startupTypeSetting.Value == WineStartupType.Proton,
+            },
 
             new SettingsEntry<bool>("Enable Feral's GameMode", "Enable launching with Feral Interactive's GameMode CPU optimizations.", () => Program.Config.GameModeEnabled ?? true, b => Program.Config.GameModeEnabled = b)
             {
@@ -107,7 +115,7 @@ public class SettingsTabWine : SettingsTab
 
         if (ImGui.Button("Open Wine explorer (run apps in prefix)"))
         {
-            Program.CompatibilityTools.RunInPrefix("explorer", inject: false);
+            Program.CompatibilityTools.RunInPrefix("explorer", wineD3D: true, inject: true);
         }
 
         if (ImGui.Button("Kill all wine processes"))

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -38,10 +38,12 @@ public class SettingsTabWine : SettingsTab
             {
                 CheckVisibility = () => startupTypeSetting.Value == WineStartupType.Proton,
             },
+#if !FLATPAK
             new SettingsEntry<bool>("Use Steam Soldier Runtime", "Use Steam's container system. Proton is designed with this in mind, but may run without it.", () => Program.Config.UseSoldier ?? true, b => Program.Config.UseSoldier = b)
             {
                 CheckVisibility = () => startupTypeSetting.Value == WineStartupType.Proton,
             },
+#endif
             new SettingsEntry<bool>("Use Reaper", "Use Steam's reaper process to launch the game.", () => Program.Config.UseReaper ?? false, b => Program.Config.UseReaper = b)
             {
                 CheckVisibility = () => startupTypeSetting.Value == WineStartupType.Proton,
@@ -88,16 +90,12 @@ public class SettingsTabWine : SettingsTab
     {
         base.Draw();
 
-        // if (!Program.CompatibilityTools.IsToolDownloaded || startupTypeSetting.Value == WineStartupType.Proton)
-        // {
-        //     ImGui.BeginDisabled();
-        //     if (startupTypeSetting.Value == WineStartupType.Proton)
-        //         ImGui.Text("These options do not work properly with Proton yet.");
-        //     else
-        //         ImGui.Text("Compatibility tool isn't set up. Please start the game at least once.");
-
-        //     ImGui.Dummy(new Vector2(10));
-        // }
+        if (!Program.CompatibilityTools.IsToolDownloaded && Program.Config.WineStartupType == WineStartupType.Managed)
+        {
+            ImGui.BeginDisabled();
+            ImGui.Text("Compatibility tool isn't set up. Please start the game at least once.");
+            ImGui.Dummy(new Vector2(10));
+        }
 
         if (ImGui.Button("Open prefix"))
         {
@@ -123,10 +121,10 @@ public class SettingsTabWine : SettingsTab
             Program.CompatibilityTools.Kill();
         }
 
-        // if (!Program.CompatibilityTools.IsToolDownloaded || startupTypeSetting.Value == WineStartupType.Proton)
-        // {
-        //     ImGui.EndDisabled();
-        // }
+        if (!Program.CompatibilityTools.IsToolDownloaded && Program.Config.WineStartupType == WineStartupType.Managed)
+        {
+            ImGui.EndDisabled();
+        }
     }
 
     public override void Save()

--- a/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
+++ b/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
@@ -67,7 +67,12 @@ public interface ILauncherConfig
     public string? WineBinaryPath { get; set; }
 
     public string? SteamPath { get; set; }
+
     public string? ProtonVersion { get; set; }
+
+    public bool? UseSoldier { get; set; }
+
+    public bool? UseReaper { get; set; }
 
     public bool? GameModeEnabled { get; set; }
 

--- a/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
+++ b/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
@@ -66,6 +66,9 @@ public interface ILauncherConfig
 
     public string? WineBinaryPath { get; set; }
 
+    public string? SteamPath { get; set; }
+    public string? ProtonVersion { get; set; }
+
     public bool? GameModeEnabled { get; set; }
 
     public bool? DxvkAsyncEnabled { get; set; }

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -114,7 +114,10 @@ class Program
 
         Config.WineStartupType ??= WineStartupType.Managed;
         Config.WineBinaryPath ??= "/usr/bin";
-        Config.SteamPath = string.IsNullOrEmpty(Config.SteamPath) ? Path.Combine(System.Environment.GetEnvironmentVariable("HOME"), ".steam", "root") : Config.SteamPath;        Config.ProtonVersion ??= "Proton 7.0";
+        Config.SteamPath = string.IsNullOrEmpty(Config.SteamPath) ? Path.Combine(System.Environment.GetEnvironmentVariable("HOME"), ".steam", "root") : Config.SteamPath;
+        Config.ProtonVersion ??= "Proton 7.0";
+        Config.UseSoldier ??= true;
+        Config.UseReaper ??= false;
         Config.WineDebugVars ??= "-all";
     }
 
@@ -299,8 +302,8 @@ class Program
         var wineLogFile = new FileInfo(Path.Combine(storage.GetFolder("logs").FullName, "wine.log"));
         var winePrefix = storage.GetFolder("wineprefix");
         var protonPrefix = storage.GetFolder("protonprefix");
-        var protonSettings = new ProtonSettings(Config.SteamPath, ProtonManager.GetPath(Config.ProtonVersion), Config.GamePath.FullName, Config.GameConfigPath.FullName, appId: SteamAppId);
-        var wineSettings = new WineSettings(Config.WineStartupType, Config.WineBinaryPath, protonSettings, Config.WineDebugVars, wineLogFile, winePrefix, protonPrefix, Config.ESyncEnabled, Config.FSyncEnabled);
+        var protonSettings = new ProtonSettings(protonPrefix, Config.SteamPath, ProtonManager.GetPath(Config.ProtonVersion), Config.GamePath.FullName, Config.GameConfigPath.FullName, SteamAppId, Config.UseSoldier.Value, Config.UseReaper.Value);
+        var wineSettings = new WineSettings(Config.WineStartupType, Config.WineBinaryPath, protonSettings, Config.WineDebugVars, wineLogFile, winePrefix, Config.ESyncEnabled, Config.FSyncEnabled);
         var toolsFolder = storage.GetFolder("compatibilitytool");
         CompatibilityTools = new CompatibilityTools(wineSettings, Config.DxvkHudType, Config.GameModeEnabled, Config.DxvkAsyncEnabled, toolsFolder);
     }

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -121,6 +121,8 @@ class Program
     public const uint STEAM_APP_ID = 39210;
     public const uint STEAM_APP_ID_FT = 312060;
 
+    public static string SteamAppId = "312060";
+
     private static void Main(string[] args)
     {
         storage = new Storage(APP_NAME);
@@ -160,12 +162,14 @@ class Program
                 {
                     Steam.Initialize(appId);
                     Log.Information($"Trying to load Steam AppID {appId}... Okay");
+                    SteamAppId = appId.ToString();
                 }
                 catch (Exception ex)
                 {
                     Log.Error(ex, $"Trying to load Steam AppID {appId}... Failed. Falling back to AppID {altId}.");
                     Steam.Initialize(altId);
                     Log.Information($"Trying to load Steam AppID {altId}... Okay");
+                    SteamAppId = altId.ToString();
                 }
             }
             else
@@ -295,7 +299,7 @@ class Program
         var wineLogFile = new FileInfo(Path.Combine(storage.GetFolder("logs").FullName, "wine.log"));
         var winePrefix = storage.GetFolder("wineprefix");
         var protonPrefix = storage.GetFolder("protonprefix");
-        var protonSettings = new ProtonSettings(Config.SteamPath, ProtonManager.GetPath(Config.ProtonVersion), Config.GamePath.FullName, Config.GameConfigPath.FullName);
+        var protonSettings = new ProtonSettings(Config.SteamPath, ProtonManager.GetPath(Config.ProtonVersion), Config.GamePath.FullName, Config.GameConfigPath.FullName, appId: SteamAppId);
         var wineSettings = new WineSettings(Config.WineStartupType, Config.WineBinaryPath, protonSettings, Config.WineDebugVars, wineLogFile, winePrefix, protonPrefix, Config.ESyncEnabled, Config.FSyncEnabled);
         var toolsFolder = storage.GetFolder("compatibilitytool");
         CompatibilityTools = new CompatibilityTools(wineSettings, Config.DxvkHudType, Config.GameModeEnabled, Config.DxvkAsyncEnabled, toolsFolder);

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -128,7 +128,7 @@ class Program
         SetupLogging(args);
         LoadConfig(storage);
         ProtonManager.GetVersions(Config.SteamPath);
-        Config.ProtonVersion = ProtonManager.CheckVersion(Config.ProtonVersion) ? Config.ProtonVersion : ProtonManager.GetDefaultVersion();
+        Config.ProtonVersion = ProtonManager.VersionExists(Config.ProtonVersion) ? Config.ProtonVersion : ProtonManager.GetDefaultVersion();
 
         Secrets = GetSecretProvider(storage);
 

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -303,9 +303,9 @@ class Program
         var winePrefix = storage.GetFolder("wineprefix");
         var protonPrefix = storage.GetFolder("protonprefix");
         var protonSettings = new ProtonSettings(protonPrefix, Config.SteamPath, ProtonManager.GetPath(Config.ProtonVersion), Config.GamePath.FullName, Config.GameConfigPath.FullName, SteamAppId, Config.UseSoldier.Value, Config.UseReaper.Value);
-        var wineSettings = new WineSettings(Config.WineStartupType, Config.WineBinaryPath, protonSettings, Config.WineDebugVars, wineLogFile, winePrefix, Config.ESyncEnabled, Config.FSyncEnabled);
+        var wineSettings = new WineSettings(Config.WineStartupType, Config.WineBinaryPath, Config.WineDebugVars, wineLogFile, winePrefix, Config.ESyncEnabled, Config.FSyncEnabled);
         var toolsFolder = storage.GetFolder("compatibilitytool");
-        CompatibilityTools = new CompatibilityTools(wineSettings, Config.DxvkHudType, Config.GameModeEnabled, Config.DxvkAsyncEnabled, toolsFolder);
+        CompatibilityTools = new CompatibilityTools(wineSettings, protonSettings, Config.DxvkHudType, Config.GameModeEnabled, Config.DxvkAsyncEnabled, toolsFolder);
     }
 
     public static void ShowWindow()

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -114,6 +114,8 @@ class Program
 
         Config.WineStartupType ??= WineStartupType.Managed;
         Config.WineBinaryPath ??= "/usr/bin";
+        Config.SteamPath ??= Path.Combine(System.Environment.GetEnvironmentVariable("HOME"), ".steam", "root");
+        Config.ProtonVersion ??= "Proton 7.0";
         Config.WineDebugVars ??= "-all";
     }
 
@@ -125,6 +127,7 @@ class Program
         storage = new Storage(APP_NAME);
         SetupLogging(args);
         LoadConfig(storage);
+        ProtonManager.GetVersions(Config.SteamPath);
 
         Secrets = GetSecretProvider(storage);
 
@@ -276,7 +279,8 @@ class Program
     {
         var wineLogFile = new FileInfo(Path.Combine(storage.GetFolder("logs").FullName, "wine.log"));
         var winePrefix = storage.GetFolder("wineprefix");
-        var wineSettings = new WineSettings(Config.WineStartupType, Config.WineBinaryPath, Config.WineDebugVars, wineLogFile, winePrefix, Config.ESyncEnabled, Config.FSyncEnabled);
+        var protonPrefix = storage.GetFolder("protonprefix");
+        var wineSettings = new WineSettings(Config.WineStartupType, Config.WineBinaryPath, Config.SteamPath, ProtonManager.GetPath(Config.ProtonVersion), Config.WineDebugVars, wineLogFile, winePrefix, protonPrefix, Config.ESyncEnabled, Config.FSyncEnabled);
         var toolsFolder = storage.GetFolder("compatibilitytool");
         CompatibilityTools = new CompatibilityTools(wineSettings, Config.DxvkHudType, Config.GameModeEnabled, Config.DxvkAsyncEnabled, toolsFolder);
     }

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -295,7 +295,8 @@ class Program
         var wineLogFile = new FileInfo(Path.Combine(storage.GetFolder("logs").FullName, "wine.log"));
         var winePrefix = storage.GetFolder("wineprefix");
         var protonPrefix = storage.GetFolder("protonprefix");
-        var wineSettings = new WineSettings(Config.WineStartupType, Config.WineBinaryPath, Config.SteamPath, ProtonManager.GetPath(Config.ProtonVersion), Config.WineDebugVars, wineLogFile, winePrefix, protonPrefix, Config.ESyncEnabled, Config.FSyncEnabled);
+        var protonSettings = new ProtonSettings(Config.SteamPath, ProtonManager.GetPath(Config.ProtonVersion), Config.GamePath.FullName, Config.GameConfigPath.FullName);
+        var wineSettings = new WineSettings(Config.WineStartupType, Config.WineBinaryPath, protonSettings, Config.WineDebugVars, wineLogFile, winePrefix, protonPrefix, Config.ESyncEnabled, Config.FSyncEnabled);
         var toolsFolder = storage.GetFolder("compatibilitytool");
         CompatibilityTools = new CompatibilityTools(wineSettings, Config.DxvkHudType, Config.GameModeEnabled, Config.DxvkAsyncEnabled, toolsFolder);
     }

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -128,6 +128,7 @@ class Program
         SetupLogging(args);
         LoadConfig(storage);
         ProtonManager.GetVersions(Config.SteamPath);
+        Config.ProtonVersion = ProtonManager.CheckVersion(Config.ProtonVersion) ? Config.ProtonVersion : ProtonManager.GetDefaultVersion();
 
         Secrets = GetSecretProvider(storage);
 

--- a/src/XIVLauncher.Core/ProtonManager.cs
+++ b/src/XIVLauncher.Core/ProtonManager.cs
@@ -28,6 +28,19 @@ public static class ProtonManager
 
     public static string GetPath(string name)
     {
-        return Versions[name];
+        if (Versions.ContainsKey(name))
+            return Versions[name];
+        return Versions[GetDefaultVersion()];
+    }
+
+    public static string GetDefaultVersion()
+    {
+        if (CheckVersion("Proton 7.0")) return "Proton 7.0";
+        return Versions.First().Key;
+    }
+
+    public static bool CheckVersion(string name)
+    {
+        return (Versions.ContainsKey(name)) ? true : false;
     }
 }

--- a/src/XIVLauncher.Core/ProtonManager.cs
+++ b/src/XIVLauncher.Core/ProtonManager.cs
@@ -15,31 +15,53 @@ public static class ProtonManager
         Versions = new Dictionary<string, string>();
         var commonDir = new DirectoryInfo(Path.Combine(steamRoot, "steamapps","common"));
         var compatDir = new DirectoryInfo(Path.Combine(steamRoot, "compatibilitytools.d"));
+        var steamRootExists = true;
 
-        Console.WriteLine($"Common Directory: {commonDir.FullName}");
-        Console.WriteLine($"Compat DIrectory: {compatDir.FullName}");
         try
         {
-            var commonDirs = commonDir.GetDirectories("Proton*");
-            foreach (var dir in commonDirs)
-                if (File.Exists(Path.Combine(dir.FullName,"proton"))) Versions.Add(dir.Name, dir.FullName);
+            if (Directory.Exists(steamRoot))
+            {
+                Log.Information($"Steam Root is {steamRoot}");
+                Log.Verbose($"Steam Common Directory is {commonDir.FullName}");
+                Log.Verbose($"Steam Compatibility Tools Directory is {compatDir.FullName}");
+            }
+            else
+            {
+                throw new DirectoryNotFoundException($"Steam Root directory \"{steamRoot}\" does not exist or is not a directory.");
+            }
         }
         catch (DirectoryNotFoundException ex)
         {
-            Log.Error(ex, $"Couldn't find any Proton versions in {commonDir}. Check launcher.ini and make sure that SteamPath points to your local Steam root. This is probably something like /home/deck/.steam/root or /home/deck/.local/share/Steam.");
+            Log.Error(ex, "No Steam directory found. Proton disabled.");
+            steamRootExists = false;
         }
-        try {
-            var compatDirs = compatDir.GetDirectories("*Proton*");
-            foreach (var dir in compatDirs)
-                if (File.Exists(Path.Combine(dir.FullName,"proton"))) Versions.Add(dir.Name, dir.FullName);
-        }
-        catch (DirectoryNotFoundException ex)
+        
+        if (steamRootExists)
         {
-            Log.Error(ex, $"Couldn't find any Proton versions in {compatDir}. Check launcher.ini and make sure that SteamPath points to your local Steam root. This is probably something like /home/deck/.steam/root or /home/deck/.local/share/Steam.");
+            try
+            {
+
+                var commonDirs = commonDir.GetDirectories("Proton*");
+                foreach (var dir in commonDirs)
+                    if (File.Exists(Path.Combine(dir.FullName,"proton"))) Versions.Add(dir.Name, dir.FullName);
+            }
+            catch (DirectoryNotFoundException ex)
+            {
+                Log.Error(ex, $"Couldn't find any Proton versions in {commonDir}. Check launcher.ini and make sure that SteamPath points to your local Steam root. This is probably something like /home/deck/.steam/root or /home/deck/.local/share/Steam.");
+            }
+            try {
+                var compatDirs = compatDir.GetDirectories("*Proton*");
+                foreach (var dir in compatDirs)
+                    if (File.Exists(Path.Combine(dir.FullName,"proton"))) Versions.Add(dir.Name, dir.FullName);
+            }
+            catch (DirectoryNotFoundException ex)
+            {
+                Log.Error(ex, $"Couldn't find any Proton versions in {compatDir}. Check launcher.ini and make sure that SteamPath points to your local Steam root. This is probably something like /home/deck/.steam/root or /home/deck/.local/share/Steam.");
+            }
         }
 
         if (Versions.Count == 0)
-            Versions.Add("ERROR", "No valid Proton verions found. Bad SteamPath or Steam not installed.");
+            Versions.Add("DISABLED", "No valid Proton verions found. Bad SteamPath or Steam not installed.");
     }
 
     public static string GetPath(string name)
@@ -62,6 +84,6 @@ public static class ProtonManager
 
     public static bool IsValid()
     {
-        return Versions.ContainsKey("ERROR") ? false : true;
+        return Versions.ContainsKey("DISABLED") ? false : true;
     }
 }

--- a/src/XIVLauncher.Core/ProtonManager.cs
+++ b/src/XIVLauncher.Core/ProtonManager.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace XIVLauncher.Core;
+
+public static class ProtonManager
+{
+    public static Dictionary<string, string> Versions { get; private set; }
+
+    public static void GetVersions(string steamRoot)
+    {
+        Versions = new Dictionary<string, string>();
+        var commonDir = new DirectoryInfo(Path.Combine(steamRoot, "steamapps","common"));
+        var compatDir = new DirectoryInfo(Path.Combine(steamRoot, "compatibilitytools.d"));
+
+        Console.WriteLine($"Common Directory: {commonDir.FullName}");
+        Console.WriteLine($"Compat DIrectory: {compatDir.FullName}");
+        var commonDirs = commonDir.GetDirectories("Proton*");
+        var compatDirs = compatDir.GetDirectories("*Proton*");
+
+        foreach (var dir in commonDirs)
+            if (File.Exists(Path.Combine(dir.FullName,"proton"))) Versions.Add(dir.Name, dir.FullName);
+
+        foreach (var dir in compatDirs)
+            if (File.Exists(Path.Combine(dir.FullName,"proton"))) Versions.Add(dir.Name, dir.FullName);
+    }
+
+    public static string GetPath(string name)
+    {
+        return Versions[name];
+    }
+}


### PR DESCRIPTION
This PR adds support for Proton as a runner. See [PR#1266](https://github.com/goatcorp/FFXIVQuickLauncher/pull/1266) for the acompanying patch on the FFXIVQuickLauncher repo.

When Proton is selected as a Wine Installation Type, a new pulldown menu will be exposed that lists all the proton versions installed in the user's steam install. This includes both Valve versions and custom versions such as GE-Proton. This negates the need for the launcher to handle downloads; third party programs like ProtonUp can handle custom proton, and Steam will handle normal proton.

Options such as Esync, Fsync, and DXVK async are passed correctly, although DXVK async isn't present in Proton 7, and the newest versions of GE-Proton use DXVK 2.1, which doesn't use or need it. It works fine with older versions, though.

Here's some pictures (Troubleshooting tab is from [PR#32](https://github.com/goatcorp/XIVLauncher.Core/pull/32)):

![Add-Proton-1](https://user-images.githubusercontent.com/109918887/217163907-bf6da528-eda2-404e-8d87-9f927edcf4c0.png)


![Add-Proton-2](https://user-images.githubusercontent.com/109918887/217163911-db5229c5-d545-4834-aaf6-2ad6ad74f8e7.png)

Dalamud works:
![Add-Proton-3](https://user-images.githubusercontent.com/109918887/217163912-cfc8014e-2325-48de-a24f-40140f9fc31e.png)

So does GShade (and presumably reShade):
![Add-Proton-4](https://user-images.githubusercontent.com/109918887/217163929-3bb3cd13-3a67-43ac-97e4-15d58012c2d5.png)
