### PR TITLE
Subtle UI/UX Adjustments

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/ActionButtons.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/ActionButtons.cs
@@ -14,25 +14,40 @@ public class ActionButtons : Component
         var btnSize = new Vector2(80) * ImGuiHelpers.GlobalScale;
 
         ImGui.PushFont(FontManager.IconFont);
-
+        
+        ImGui.BeginDisabled(this.OnQueueButtonClicked == null);
         if (ImGui.Button(FontAwesomeIcon.Clock.ToIconString(), btnSize))
         {
             this.OnQueueButtonClicked?.Invoke();
         }
+        ImGui.PushFont(FontManager.TextFont);
+        ImGuiHelpers.AddTooltip("Queue");
+        ImGui.PopFont();
+        ImGui.EndDisabled();
 
         ImGui.SameLine();
-
+        
+        ImGui.BeginDisabled(this.OnStatusButtonClicked == null);
         if (ImGui.Button(FontAwesomeIcon.Globe.ToIconString(), btnSize))
         {
             this.OnStatusButtonClicked?.Invoke();
         }
+        ImGui.PushFont(FontManager.TextFont);
+        ImGuiHelpers.AddTooltip("Service Status");
+        ImGui.PopFont();
+        ImGui.EndDisabled();
 
         ImGui.SameLine();
 
+        ImGui.BeginDisabled(this.OnSettingsButtonClicked == null);
         if (ImGui.Button(FontAwesomeIcon.Cog.ToIconString(), btnSize))
         {
             this.OnSettingsButtonClicked?.Invoke();
         }
+        ImGui.PushFont(FontManager.TextFont);
+        ImGuiHelpers.AddTooltip("Settings");
+        ImGui.PopFont();
+        ImGui.EndDisabled();
 
         ImGui.PopFont();
 

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -43,6 +43,7 @@ public class MainPage : Page
 
         this.loginFrame.OnLogin += this.ProcessLogin;
         this.actionButtons.OnSettingsButtonClicked += () => this.App.State = LauncherApp.LauncherState.Settings;
+        this.actionButtons.OnStatusButtonClicked += () => AppUtil.OpenBrowser("https://is.xivup.com/");
 
         this.Padding = new Vector2(32f, 32f);
 
@@ -75,8 +76,8 @@ public class MainPage : Page
 
         ImGui.SameLine();
 
-        this.AccountSwitcher.Draw();
         this.loginFrame.Draw();
+        this.AccountSwitcher.Draw();
 
         this.actionButtons.Draw();
     }

--- a/src/XIVLauncher.Core/Components/MainPage/NewsFrame.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/NewsFrame.cs
@@ -71,8 +71,6 @@ public class NewsFrame : Component
         {
             ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(32f, 32f));
 
-            //ImGui.Text("awooga");
-
             if (this.newsLoaded)
             {
                 var banner = this.banners[this.currentBanner];
@@ -84,7 +82,7 @@ public class NewsFrame : Component
                 ImGui.Dummy(new Vector2(15));
 
                 void ShowNewsEntry(News newsEntry)
-                {
+                {  
                     ImGui.Text(newsEntry.Title);
 
                     if (ImGui.IsItemClicked(ImGuiMouseButton.Left) && !string.IsNullOrEmpty(newsEntry.Url))
@@ -93,13 +91,15 @@ public class NewsFrame : Component
                     }
                 }
 
+                ImGui.TextDisabled("News");
                 foreach (News newsEntry in this.headlines.News)
                 {
                     ShowNewsEntry(newsEntry);
                 }
 
-                ImGui.Separator();
+                ImGui.Spacing();
 
+                ImGui.TextDisabled("Topics");
                 foreach (News topic in this.headlines.Topics)
                 {
                     ShowNewsEntry(topic);
@@ -107,7 +107,7 @@ public class NewsFrame : Component
             }
             else
             {
-                ImGui.Text("News are loading...");
+                ImGui.Text("News is loading...");
             }
 
             ImGui.PopStyleVar();

--- a/src/XIVLauncher.Core/Components/SettingsPage/SettingsPage.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/SettingsPage.cs
@@ -64,12 +64,12 @@ public class SettingsPage : Page
                 if (ImGui.BeginTabItem("Search Results"))
                 {
                     var any = false;
-                    
+
                     foreach (SettingsTab settingsTab in this.tabs)
                     {
                         if (settingsTab.IsUnixExclusive && Environment.OSVersion.Platform != PlatformID.Unix)
                             continue;
-                    
+
                         var eligible = settingsTab.Entries
                             .Where(x => x.Name.Contains(this.searchInput.Trim(),
                                 StringComparison.InvariantCultureIgnoreCase));
@@ -88,7 +88,7 @@ public class SettingsPage : Page
                             {
                                 if (!settingsTabEntry.IsVisible)
                                     continue;
-                                
+
                                 settingsTabEntry.Draw();
                             }
 

--- a/src/XIVLauncher.Core/Components/SettingsPage/SettingsPage.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/SettingsPage.cs
@@ -64,33 +64,39 @@ public class SettingsPage : Page
                 if (ImGui.BeginTabItem("Search Results"))
                 {
                     var any = false;
-
+                    
                     foreach (SettingsTab settingsTab in this.tabs)
                     {
                         if (settingsTab.IsUnixExclusive && Environment.OSVersion.Platform != PlatformID.Unix)
                             continue;
-
-                        var eligible = settingsTab.Entries.Where(x => x.Name.ToLower().Contains(this.searchInput.ToLower())).ToArray();
+                    
+                        var eligible = settingsTab.Entries
+                            .Where(x => x.Name.Contains(this.searchInput.Trim(),
+                                StringComparison.InvariantCultureIgnoreCase));
 
                         if (!eligible.Any())
                             continue;
 
                         any = true;
 
-                        ImGui.TextColored(ImGuiColors.DalamudGrey, settingsTab.Title);
-                        ImGui.Dummy(new Vector2(5));
-
-                        foreach (SettingsEntry settingsTabEntry in settingsTab.Entries)
+                        if (ImGui.BeginChild("SearchResults"))
                         {
-                            if (!settingsTabEntry.Name.ToLower().Contains(this.searchInput.ToLower()))
-                                continue;
+                            ImGui.TextColored(ImGuiColors.DalamudGrey, settingsTab.Title);
+                            ImGui.Dummy(new Vector2(5));
 
-                            settingsTabEntry.Draw();
+                            foreach (SettingsEntry settingsTabEntry in eligible)
+                            {
+                                if (!settingsTabEntry.IsVisible)
+                                    continue;
+                                
+                                settingsTabEntry.Draw();
+                            }
+
+                            ImGui.Separator();
+
+                            ImGui.Dummy(new Vector2(10));
                         }
-
-                        ImGui.Separator();
-
-                        ImGui.Dummy(new Vector2(10));
+                        ImGui.EndChild();
                     }
 
                     if (!any)
@@ -137,8 +143,8 @@ public class SettingsPage : Page
         ImGui.PopFont();
 
         var vpSize = ImGuiHelpers.ViewportSize;
-        ImGui.SetCursorPos(new Vector2(vpSize.X - 250, 4));
-        ImGui.SetNextItemWidth(240);
+        ImGui.SetCursorPos(new Vector2(vpSize.X - 260, 4));
+        ImGui.SetNextItemWidth(250);
         ImGui.InputTextWithHint("###searchInput", "Search for settings...", ref this.searchInput, 100);
 
         base.Draw();

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabAbout.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabAbout.cs
@@ -11,10 +11,7 @@ public class SettingsTabAbout : SettingsTab
 {
     private readonly TextureWrap logoTexture;
 
-    public override SettingsEntry[] Entries { get; } =
-    {
-        new SettingsEntry<bool>("Use UID Cache", "Tries to save your login token for the next start.", () => Program.Config.IsUidCacheEnabled ?? false, x => Program.Config.IsUidCacheEnabled = x),
-    };
+    public override SettingsEntry[] Entries  => Array.Empty<SettingsEntry>();
 
     public override string Title => "About";
 
@@ -25,21 +22,19 @@ public class SettingsTabAbout : SettingsTab
 
     public override void Draw()
     {
-        ImGui.Text($"This is XIVLauncher Core v{AppUtil.GetAssemblyVersion()}({AppUtil.GetGitHash()})");
-        ImGui.Text("By goaaats");
+        ImGui.Image(this.logoTexture.ImGuiHandle, new Vector2(256) * ImGuiHelpers.GlobalScale);
 
-#if FLATPAK
-        ImGui.TextColored(ImGuiColors.DalamudRed, "THIS IS A FLATPAK!!!");
-#endif
+        ImGui.Text($"XIVLauncher Core v{AppUtil.GetAssemblyVersion()}({AppUtil.GetGitHash()})");
+        ImGui.Text("By goaaats");
 
         if (ImGui.IsItemClicked(ImGuiMouseButton.Left))
             AppUtil.OpenBrowser("https://github.com/goaaats");
 
         ImGui.Dummy(new Vector2(20));
 
-        if (ImGui.Button("Open GitHub"))
+        if (ImGui.Button("Open Repository"))
         {
-            AppUtil.OpenBrowser("https://github.com/goatcorp/FFXIVQuickLauncher");
+            AppUtil.OpenBrowser("https://github.com/goatcorp/XIVLauncher.Core");
         }
 
         if (ImGui.Button("Join our Discord"))
@@ -47,7 +42,7 @@ public class SettingsTabAbout : SettingsTab
             AppUtil.OpenBrowser("https://discord.gg/3NMcUV5");
         }
 
-        if (ImGui.Button("See software licenses"))
+        if (ImGui.Button("See Software Licenses"))
         {
             PlatformHelpers.OpenBrowser(Path.Combine(AppContext.BaseDirectory, "license.txt"));
         }
@@ -58,10 +53,6 @@ public class SettingsTabAbout : SettingsTab
             PlatformHelpers.OpenBrowser(Program.storage.GetFolder("logs").FullName);
         }
 
-        ImGui.Dummy(new Vector2(20));
-
-        ImGui.Image(this.logoTexture.ImGuiHandle, new Vector2(256) * ImGuiHelpers.GlobalScale);
-            
         base.Draw();
     }
 }

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDalamud.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDalamud.cs
@@ -18,7 +18,7 @@ public class SettingsTabDalamud : SettingsTab
             },
         },
 
-        new NumericSettingsEntry("Injection Delay", "Choose how long to wait after the game has loaded before injecting.", () => Program.Config.DalamudLoadDelay, delay => Program.Config.DalamudLoadDelay = delay, 0, int.MaxValue, 1000),
+        new NumericSettingsEntry("Injection Delay (ms)", "Choose how long to wait after the game has loaded before injecting.", () => Program.Config.DalamudLoadDelay, delay => Program.Config.DalamudLoadDelay = delay, 0, int.MaxValue, 1000),
     };
 
     public override string Title => "Dalamud";

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDebug.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDebug.cs
@@ -6,26 +6,45 @@ namespace XIVLauncher.Core.Components.SettingsPage.Tabs;
 public class SettingsTabDebug : SettingsTab
 {
     public override SettingsEntry[] Entries => Array.Empty<SettingsEntry>();
-    public override string Title => "Debug Info";
+    public override string Title => "Debug";
 
     public override void Draw()
     {
+        ImGui.TextUnformatted("Generic Information");
+        ImGui.Separator();
+        ImGui.TextUnformatted($"Operating System: {Environment.OSVersion}");
+        ImGui.TextUnformatted($"Runtime Version: {Environment.Version}"); 
+        
         if (Program.IsSteamDeckHardware)
-            ImGui.Text("Is Steam Deck hardware");
+            ImGui.Text("Steam Deck Hardware Detected");
 
         if (Program.IsSteamDeckGamingMode)
-            ImGui.Text("Is Steam Deck");
+            ImGui.Text("Steam Deck Gaming Mode Detected");
 
+#if FLATPAK
+            ImGui.Text("Running as a Flatpak");
+#endif
+        
+        ImGui.Spacing();
+
+        ImGui.TextUnformatted("Environment Information");
         ImGui.Separator();
-
-        ImGui.PushTextWrapPos(0);
-
-        foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
-        {
-            ImGui.TextUnformatted($"{entry.Key}={entry.Value}");
-        }
-
-        ImGui.PopTextWrapPos();
+            if(ImGui.BeginTable("EnvironmentTable", 2, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg | ImGuiTableFlags.Resizable | ImGuiTableFlags.ScrollY))
+            {
+                ImGui.TableSetupScrollFreeze(0, 1);
+                ImGui.TableSetupColumn("Key", ImGuiTableColumnFlags.WidthStretch, 0.35f);
+                ImGui.TableSetupColumn("Value");
+                ImGui.TableHeadersRow();
+                foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+                {   
+                    ImGui.TableNextRow();
+                    ImGui.TableNextColumn();
+                    ImGuiHelpers.TextWrapped(entry.Key?.ToString() ?? "null");
+                    ImGui.TableNextColumn();
+                    ImGuiHelpers.TextWrapped(entry.Value?.ToString() ?? "null");
+                }
+                ImGui.EndTable();
+            }
 
         base.Draw();
     }

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDebug.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDebug.cs
@@ -24,7 +24,7 @@ public class SettingsTabDebug : SettingsTab
 #if FLATPAK
             ImGui.Text("Running as a Flatpak");
 #endif
-        
+
         ImGui.Spacing();
 
         ImGui.TextUnformatted("Environment Information");

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
@@ -6,7 +6,7 @@ public class SettingsTabGame : SettingsTab
 {
     public override SettingsEntry[] Entries { get; } =
     {
-        new SettingsEntry<DirectoryInfo>("Game Path", "Where the game is installed to.", () => Program.Config.GamePath, x => Program.Config.GamePath = x)
+        new SettingsEntry<DirectoryInfo>("Game Path", "Where the game is or will be installed.", () => Program.Config.GamePath, x => Program.Config.GamePath = x)
         {
             CheckValidity = x =>
             {
@@ -20,7 +20,7 @@ public class SettingsTabGame : SettingsTab
             }
         },
 
-        new SettingsEntry<DirectoryInfo>("Game Config Path", "Where the user config files will be stored.", () => Program.Config.GameConfigPath, x => Program.Config.GameConfigPath = x)
+        new SettingsEntry<DirectoryInfo>("Game Configuration Path", "Where your user config files will be stored.", () => Program.Config.GameConfigPath, x => Program.Config.GameConfigPath = x)
         {
             CheckValidity = x => string.IsNullOrWhiteSpace(x?.FullName) ? "Game Config Path is not set." : null,
 
@@ -36,9 +36,10 @@ public class SettingsTabGame : SettingsTab
         new SettingsEntry<string>("Additional Arguments", "Additional args to start the game with", () => Program.Config.AdditionalArgs, x => Program.Config.AdditionalArgs = x),
         new SettingsEntry<ClientLanguage>("Game Language", "Select the game's language.", () => Program.Config.ClientLanguage ?? ClientLanguage.English, x => Program.Config.ClientLanguage = x),
         new SettingsEntry<DpiAwareness>("Game DPI Awareness", "Select the game's DPI Awareness. Change this if the game's scaling looks wrong.", () => Program.Config.DpiAwareness ?? DpiAwareness.Unaware, x => Program.Config.DpiAwareness = x),
-        new SettingsEntry<bool>("Free trial account", "Check this if you are using a free trial account.", () => Program.Config.IsFt ?? false, x => Program.Config.IsFt = x),
+        new SettingsEntry<bool>("Free Trial Account", "Check this if you are using a free trial account.", () => Program.Config.IsFt ?? false, x => Program.Config.IsFt = x),
         new SettingsEntry<bool>("Use XIVLauncher authenticator/OTP macros", "Check this if you want to use the XIVLauncher authenticator app or macros.", () => Program.Config.IsOtpServer ?? false, x => Program.Config.IsOtpServer = x),
         new SettingsEntry<bool>("Ignore Steam", "Check this if you do not want XIVLauncher to communicate with Steam (Requires Restart).", () => Program.Config.IsIgnoringSteam ?? false, x => Program.Config.IsIgnoringSteam = x),
+        new SettingsEntry<bool>("Use UID Cache", "Tries to save your login token for the next start.", () => Program.Config.IsUidCacheEnabled ?? false, x => Program.Config.IsUidCacheEnabled = x),
     };
 
     public override string Title => "Game";

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -14,7 +14,7 @@ public class SettingsTabWine : SettingsTab
     {
         Entries = new SettingsEntry[]
         {
-            startupTypeSetting = new SettingsEntry<WineStartupType>("Installation Type", "Choose how XIVLauncher will start and manage your game installation.",
+            startupTypeSetting = new SettingsEntry<WineStartupType>("Wine Version", "Choose how XIVLauncher will start and manage your wine installation.",
                 () => Program.Config.WineStartupType ?? WineStartupType.Managed, x => Program.Config.WineStartupType = x),
 
             new SettingsEntry<string>("Wine Binary Path",
@@ -30,7 +30,7 @@ public class SettingsTabWine : SettingsTab
                 CheckValidity = b =>
                 {
                     if (b == true && (!File.Exists("/usr/lib/libgamemodeauto.so.0") && !File.Exists("/app/lib/libgamemodeauto.so.0")))
-                        return "GameMode not detected.";
+                        return "GameMode was not detected on your system.";
 
                     return null;
                 }

--- a/src/XIVLauncher.Core/ImGuiHelpers.cs
+++ b/src/XIVLauncher.Core/ImGuiHelpers.cs
@@ -33,4 +33,14 @@ public static class ImGuiHelpers
         var window = (int)ImGui.GetWindowWidth();
         ImGui.SetCursorPosX(window / 2 - itemWidth / 2);
     }
+    
+    public static void AddTooltip(string text)
+    {
+        if (ImGui.IsItemHovered())
+        {
+            ImGui.BeginTooltip();
+            ImGui.TextUnformatted(text);
+            ImGui.EndTooltip();
+        }
+    }
 }

--- a/src/XIVLauncher.Core/LauncherApp.cs
+++ b/src/XIVLauncher.Core/LauncherApp.cs
@@ -268,7 +268,7 @@ public class LauncherApp : Component
 
         ImGui.SetNextWindowPos(new Vector2(0, 0));
         ImGui.SetNextWindowSize(ImGuiHelpers.ViewportSize);
-        ImGui.SetNextWindowBgAlpha(0.7f);
+        ImGui.SetNextWindowBgAlpha(0.75f);
 
         if (ImGui.Begin("XIVLauncher", ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse))
         {


### PR DESCRIPTION
Wanted to combine a large collection of small tweaks to the UI of XLCore that make things a little nicer.

### Home
- Added tooltips to homepage action buttons
- Made action buttons show as disabled when no callback action is set
- Added tooltips to action buttons on hover
- Made the status action open https://is.xivup.com/ just like WPF XL
- Added headings to "news" and "topics" and swapping the separator for a spacing element
- Moved the account switcher draw below the login form to prevent right-clicking the news opening it (I cannot actually find where this is happening though)

### Settings
- Simplified search functionality to use `.Contains()` with lower invariant and trimming
- Increased searchbar length
- Reformatted about page
- Added OS & Runtime version to debug page
- Put environment variables into a table on debug page
- Made capitalization consistent across all settings pages
- Changing about "Open Github" to "Open Repository" and changing its URL to point to this repository instead of WPF XL
- Moved UID cache setting to game tab
- Rephrased some settings to clarify what they do
- Removed "THIS IS A FLATPAK!!" from about page and added a "running in flatpak" message to the debug page

Overall none of these changes make any functional changes to how the launcher works