### PR TITLE
Fix: IsIgnoringSteam no longer opens Fts Error page on Steam Deck

### DIFF
--- a/src/XIVLauncher.Core/Components/FtsPage.cs
+++ b/src/XIVLauncher.Core/Components/FtsPage.cs
@@ -27,6 +27,8 @@ public class FtsPage : Page
 
         if (Program.IsSteamDeckHardware && (Program.Steam == null || !Program.Steam.IsValid))
         {
+            // If IsIgnoringSteam == true, skip the error screen. This fixes a bug with Steam Deck always showing the Fts Error screen.
+            if (App.Settings.IsIgnoringSteam ?? false) return;
             App.State = LauncherApp.LauncherState.Fts;
             this.isSteamDeckAppIdError = true;
         }

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -50,7 +50,8 @@ class Program
 
     // TODO: We don't have the steamworks api for this yet.
     public static bool IsSteamDeckHardware => Directory.Exists("/home/deck");
-    public static bool IsSteamDeckGamingMode => Steam != null && Steam.IsValid && Steam.IsRunningOnSteamDeck();
+
+    public static bool IsSteamDeckGamingMode = Steam != null && Steam.IsValid && Steam.IsRunningOnSteamDeck();
 
     private const string APP_NAME = "xlcore";
 
@@ -117,8 +118,8 @@ class Program
         Config.WineDebugVars ??= "-all";
     }
 
-    public const uint STEAM_APP_ID = 39210;
-    public const uint STEAM_APP_ID_FT = 312060;
+    public const uint STEAM_APP_ID = 39210; // FFXIV Retail Steam AppId
+    public const uint STEAM_APP_ID_FT = 312060; // FFXIV Free Trial Steam AppId
 
     private static void Main(string[] args)
     {
@@ -130,6 +131,23 @@ class Program
 
         Loc.SetupWithFallbacks();
 
+        // 
+        uint appId, altId;
+        string appName, altName;
+        if (Config.IsFt.Value)
+        {
+            appId = STEAM_APP_ID_FT;
+            altId = STEAM_APP_ID;
+            appName = "FFXIV Free Trial";
+            altName = "FFXIV Retail";
+        }
+        else
+        {
+            appId = STEAM_APP_ID;
+            altId = STEAM_APP_ID_FT;
+            appName = "FFXIV Retail";
+            altName = "FFXIV Free Trial";
+        }
         try
         {
             switch (Environment.OSVersion.Platform)
@@ -149,19 +167,18 @@ class Program
             {
                 try
                 {
-                    var appId = Config.IsFt == true ? STEAM_APP_ID_FT : STEAM_APP_ID;
                     Steam.Initialize(appId);
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "Couldn't init Steam with game AppIds, trying FT");
-                    Steam.Initialize(STEAM_APP_ID_FT);
+                    Log.Error($"Couldn't init Steam with AppId={appId} ({appName}), trying AppId={altId} ({altName})");
+                    Steam.Initialize(altId);
                 }
             }
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Steam couldn't load");
+            Log.Error(ex, "Steam couldn't load.");
         }
 
         DalamudLoadInfo = new DalamudOverlayInfoProxy();

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -117,8 +117,8 @@ class Program
         Config.WineDebugVars ??= "-all";
     }
 
-    public const uint STEAM_APP_ID = 39210; // FFXIV Retail Steam AppId
-    public const uint STEAM_APP_ID_FT = 312060; // FFXIV Free Trial Steam AppId
+    public const uint STEAM_APP_ID = 39210;
+    public const uint STEAM_APP_ID_FT = 312060;
 
     private static void Main(string[] args)
     {
@@ -130,7 +130,6 @@ class Program
 
         Loc.SetupWithFallbacks();
 
-        // 
         uint appId, altId;
         string appName, altName;
         if (Config.IsFt.Value)
@@ -170,14 +169,14 @@ class Program
                 }
                 catch (Exception ex)
                 {
-                    Log.Error($"Couldn't init Steam with AppId={appId} ({appName}), trying AppId={altId} ({altName})");
+                    Log.Error(ex, $"Couldn't init Steam with AppId={appId} ({appName}), trying AppId={altId} ({altName})");
                     Steam.Initialize(altId);
                 }
             }
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Steam couldn't load.");
+            Log.Error(ex, "Steam couldn't load");
         }
 
         DalamudLoadInfo = new DalamudOverlayInfoProxy();

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -50,8 +50,7 @@ class Program
 
     // TODO: We don't have the steamworks api for this yet.
     public static bool IsSteamDeckHardware => Directory.Exists("/home/deck");
-
-    public static bool IsSteamDeckGamingMode = Steam != null && Steam.IsValid && Steam.IsRunningOnSteamDeck();
+    public static bool IsSteamDeckGamingMode => Steam != null && Steam.IsValid && Steam.IsRunningOnSteamDeck();
 
     private const string APP_NAME = "xlcore";
 


### PR DESCRIPTION
As the title suggests. You can test by creating /home/deck, checking the option for Ignore Steam, and restarting the launcher.

Also fixes a logic bug: if Free Trial was selected in settings, and the full version was installed, the launcher would first try the FT appId, and then fall back to the FT appId again, never finding the retail version. This is probably not a common issue, but I hit it a few times with the retail version through steam and a free trial account through the SE store. So if IsFt==true, it will try FT, and fall back to retail. If IsFt==false, it will try retail and fall back to FT.