### PR TITLE
CI Updates - switch to dotnet publish and restrict releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,13 +32,13 @@ jobs:
         run: dotnet restore
 
       - name: Dotnet Build (Default)
-        run: dotnet build --configuration Release --no-restore -o ./dist/XIVLauncher.Core
+        run: dotnet publish -r linux-x64 --sc --configuration Release --no-restore -o ./dist/XIVLauncher.Core
 
       - name: Dotnet Build (Arch)
-        run: dotnet build --configuration Release -p:DefineConstants=WINE_XIV_ARCH_LINUX --no-restore -o ./dist/XIVLauncher.Core-arch
+        run: dotnet publish -r linux-x64 --sc --configuration Release -p:DefineConstants=WINE_XIV_ARCH_LINUX --no-restore -o ./dist/XIVLauncher.Core-arch
 
       - name: Dotnet Build (Fedora)
-        run: dotnet build --configuration Release -p:DefineConstants=WINE_XIV_FEDORA_LINUX --no-restore -o ./dist/XIVLauncher.Core-fedora
+        run: dotnet publish -r linux-x64 --sc --configuration Release -p:DefineConstants=WINE_XIV_FEDORA_LINUX --no-restore -o ./dist/XIVLauncher.Core-fedora
 
       - name: Dotnet Test
         run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -57,15 +57,15 @@ jobs:
 
       - name: Dotnet Build (Default)
         working-directory: ./src/XIVLauncher.Core/
-        run: dotnet build --configuration Release --no-restore -o ./dist/XIVLauncher.Core
+        run: dotnet publish -r linux-x64 --sc --configuration Release --no-restore -o ./dist/XIVLauncher.Core
 
       - name: Dotnet Build (Arch)
         working-directory: ./src/XIVLauncher.Core/
-        run: dotnet build --configuration Release -p:DefineConstants=WINE_XIV_ARCH_LINUX --no-restore -o ./dist/XIVLauncher.Core-arch
+        run: dotnet publish -r linux-x64 --sc --configuration Release -p:DefineConstants=WINE_XIV_ARCH_LINUX --no-restore -o ./dist/XIVLauncher.Core-arch
 
       - name: Dotnet Build (Fedora)
         working-directory: ./src/XIVLauncher.Core/
-        run: dotnet build --configuration Release -p:DefineConstants=WINE_XIV_FEDORA_LINUX --no-restore -o ./dist/XIVLauncher.Core-fedora
+        run: dotnet publish -r linux-x64 --sc --configuration Release -p:DefineConstants=WINE_XIV_FEDORA_LINUX --no-restore -o ./dist/XIVLauncher.Core-fedora
 
       - name: Generate nuget-dependencies.json
         working-directory: ./src/XIVLauncher.Core/

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   Release:
+	if: github.repository == 'goatcorp/XIVLauncher.Core'
     runs-on: ubuntu-latest
     env:
       # These are the user credentials that will be used to make the PR.


### PR DESCRIPTION
Minor CI updates.

This switches all `dotnet build` to `dotnet publish` commands instead, which means we can generate a single file and self-contained .Net resources. This makes builds effectively portable as long as the user has libsdl2 and aria2c installed as per their distro.

This PR also restricts the Release workflow from running unless it's on goatcorp. We may eventually want to split release into release-flatpak and release-binaries or something, so we can run them separately as needed. 

As it is, we don't release very often, but this will prevent other users' releases from attempting to update our flatpak.