### PR TITLE
Add win7 option

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -731,7 +731,7 @@ public class MainPage : Page
             }
         }
 
-        var winver = (App.Settings.SetWin7 ?? false) ? "win7" : "win10";
+        var winver = (App.Settings.SetWin7 ?? true) ? "win7" : "win10";
 
         Program.CompatibilityTools.RunInPrefix($"winecfg /v {winver}");
 

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -731,6 +731,10 @@ public class MainPage : Page
             }
         }
 
+        var winver = (App.Settings.SetWin7 ?? false) ? "win7" : "win10";
+
+        Program.CompatibilityTools.RunInPrefix($"winecfg /v {winver}");
+
         if (Environment.OSVersion.Platform == PlatformID.Win32NT)
         {
             runner = new WindowsGameRunner(dalamudLauncher, dalamudOk, Program.DalamudUpdater.Runtime);

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -50,6 +50,8 @@ public class SettingsTabWine : SettingsTab
                 }
             },
 
+            new SettingsEntry<bool>("Set Windows version to 7", "Default is 10. Setting to 7 may fix some networking issues with plugins.", () => Program.Config.SetWin7 ?? false, b => Program.Config.SetWin7 = b),
+
             new SettingsEntry<Dxvk.DxvkHudType>("DXVK Overlay", "Configure how much of the DXVK overlay is to be shown.", () => Program.Config.DxvkHudType, type => Program.Config.DxvkHudType = type),
             new SettingsEntry<string>("WINEDEBUG Variables", "Configure debug logging for wine. Useful for troubleshooting.", () => Program.Config.WineDebugVars ?? string.Empty, s => Program.Config.WineDebugVars = s)
         };

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -50,7 +50,7 @@ public class SettingsTabWine : SettingsTab
                 }
             },
 
-            new SettingsEntry<bool>("Set Windows version to 7", "Default is 10. Setting to 7 may fix some networking issues with plugins.", () => Program.Config.SetWin7 ?? false, b => Program.Config.SetWin7 = b),
+            new SettingsEntry<bool>("Set Windows version to 7", "Default for Wine 8.1+ is Windows 10, but this causes issues with some Dalamud plugins. Windows 7 is recommended for now.", () => Program.Config.SetWin7 ?? true, b => Program.Config.SetWin7 = b),
 
             new SettingsEntry<Dxvk.DxvkHudType>("DXVK Overlay", "Configure how much of the DXVK overlay is to be shown.", () => Program.Config.DxvkHudType, type => Program.Config.DxvkHudType = type),
             new SettingsEntry<string>("WINEDEBUG Variables", "Configure debug logging for wine. Useful for troubleshooting.", () => Program.Config.WineDebugVars ?? string.Empty, s => Program.Config.WineDebugVars = s)

--- a/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
+++ b/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
@@ -82,6 +82,8 @@ public interface ILauncherConfig
 
     public bool? FixIM { get; set; }
 
+    public bool? SetWin7 { get; set; }
+
     #endregion
 
     #region Dalamud

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -118,6 +118,7 @@ class Program
         Config.DxvkAsyncEnabled ??= true;
         Config.ESyncEnabled ??= true;
         Config.FSyncEnabled ??= false;
+        Config.SetWin7 ??= true;
 
         Config.WineStartupType ??= WineStartupType.Managed;
         Config.WineBinaryPath ??= "/usr/bin";


### PR DESCRIPTION
This just adds a checkbox to set the windows version to 7 instead of 10. This might fix some networking issues with plugins. Previous versions of wine defaulted to windows 7. This checkbox is toggled on by default. Unchecking will set the prefix back to windows 10.