### PR TITLE
Fix win7 code being in wrong place

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -731,10 +731,6 @@ public class MainPage : Page
             }
         }
 
-        var winver = (App.Settings.SetWin7 ?? true) ? "win7" : "win10";
-
-        Program.CompatibilityTools.RunInPrefix($"winecfg /v {winver}");
-
         if (Environment.OSVersion.Platform == PlatformID.Win32NT)
         {
             runner = new WindowsGameRunner(dalamudLauncher, dalamudOk, Program.DalamudUpdater.Runtime);
@@ -759,8 +755,10 @@ public class MainPage : Page
             var _ = Task.Run(async () =>
             {
                 var tempPath = App.Storage.GetFolder("temp");
+                var winver = (App.Settings.SetWin7 ?? true) ? "win7" : "win10";
 
                 await Program.CompatibilityTools.EnsureTool(tempPath).ConfigureAwait(false);
+                Program.CompatibilityTools.RunInPrefix($"winecfg /v {winver}");
 
                 var gameFixApply = new GameFixApply(App.Settings.GamePath, App.Settings.GameConfigPath, Program.CompatibilityTools.Settings.Prefix, tempPath);
                 gameFixApply.UpdateProgress += (text, hasProgress, progress) =>


### PR DESCRIPTION
Made a mistake with the win7 code from yesterday. Need to run this AFTER ensuring the prefix, which is what downloads wine.