### PR TITLE
[Fix] Create dxvk and wine folders no matter what

### DIFF
--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -321,6 +321,8 @@ class Program
         var winePrefix = storage.GetFolder("wineprefix");
         var wineSettings = new WineSettings(Config.WineStartupType, Config.WineBinaryPath, Config.WineDebugVars, wineLogFile, winePrefix, Config.ESyncEnabled, Config.FSyncEnabled);
         var toolsFolder = storage.GetFolder("compatibilitytool");
+        Directory.CreateDirectory(Path.Combine(toolsFolder.FullName, "dxvk"));
+        Directory.CreateDirectory(Path.Combine(toolsFolder.FullName, "beta"));
         CompatibilityTools = new CompatibilityTools(wineSettings, Config.DxvkHudType, Config.GameModeEnabled, Config.DxvkAsyncEnabled, toolsFolder);
     }
 


### PR DESCRIPTION
Alright, minor edge case. If you have an empty compatibilitytools folder (basically fresh install or manually delete it), and point to a custom wine, dxvk will fail to download because the dxvk folder doesn't exist under compatibilitytools. The result is the "Could not obtain Process Handle" error. Technically this should probably be fixed in the submodule, but this will patch it on the XL.Core side.