### PR TITLE
use NativeLibrary to try loading libgamemodeauto.so.0

### DIFF
--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -29,9 +29,10 @@ public class SettingsTabWine : SettingsTab
                 CheckVisibility = () => RuntimeInformation.IsOSPlatform(OSPlatform.Linux),
                 CheckValidity = b =>
                 {
-                    if (b == true && (!File.Exists("/usr/lib/libgamemodeauto.so.0") && !File.Exists("/app/lib/libgamemodeauto.so.0")))
+                    var handle = IntPtr.Zero;
+                    if (b == true && !NativeLibrary.TryLoad("libgamemodeauto.so.0", out handle))
                         return "GameMode was not detected on your system.";
-
+                    NativeLibrary.Free(handle);
                     return null;
                 }
             },


### PR DESCRIPTION
this removes the reliance on path checking, instead moving it to the (appropriate) dlopen(3) call that dotnet does under the hood. that call loads libs based on different variables that are set by the user. thus allowing the user to have the lib in different paths scanned by /etc/ld.so.cache, or override it by setting LD_LIBRARY_PATH.

this issue should fix #67 (and the associated gentoo bug https://bugs.gentoo.org/911936)

i tested this patch on my gentoo machine, but not in flatpaks, and i am unsure if flatpaks have the `/app/lib` in it's ld path. if anyone does now, please let me now. depending on it, the file check for the flatpak specific path might need to be re-introduced