### PR TITLE
ci: add quick way to generate nuget deps

### DIFF
--- a/.github/workflows/generate_flatpak_nuget_deps.yml
+++ b/.github/workflows/generate_flatpak_nuget_deps.yml
@@ -1,0 +1,40 @@
+name: "Nuget Dependencies"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  Generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Setup Python3
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+
+      - name: Setup Flatpak
+        run: |
+          sudo apt update -y
+          sudo apt install flatpak -y
+          flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo 
+          flatpak install --user org.freedesktop.Sdk.Extension.dotnet6/x86_64/22.08 -y # Update this when needed.
+          flatpak install --user org.freedesktop.Sdk/x86_64/22.08 -y # As well as this, if dependency generation is failing.
+
+      - name: Generate nuget-dependencies.json
+        working-directory: ./src/XIVLauncher.Core/
+        run: |
+          curl -LO https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/dotnet/flatpak-dotnet-generator.py
+          python3 flatpak-dotnet-generator.py nuget-dependencies.json XIVLauncher.Core.csproj
+
+      - name: Upload nuget-dependencies.json
+        uses: actions/upload-artifact@v3
+        with:
+          name: nuget-dependencies
+          path: |
+            ./src/XIVLauncher.Core/nuget-dependencies.json


### PR DESCRIPTION
It can be annoying to generate `nuget-dependencies.json` when needing to create local build with `flatpak-builder` so I wanted to setup a CI that can generate it on demand