### PR TITLE
Move Clear Settings button

### DIFF
--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
@@ -25,12 +25,6 @@ public class SettingsTabTroubleshooting : SettingsTab
 
         ImGui.Separator();
 
-        ImGui.Text("\nReset settings to default.");
-        if (ImGui.Button("Clear Settings"))
-        {
-            Program.ClearSettings(true);
-        }        
-
         ImGui.Text("\nClear the Wine Prefix - delete the ~/.xlcore/wineprefix folder");
         if (ImGui.Button("Clear Prefix"))
         {
@@ -53,6 +47,12 @@ public class SettingsTabTroubleshooting : SettingsTab
         if (ImGui.Button("Clear Logs"))
         {
             Program.ClearLogs(true);
+        }
+
+        ImGui.Text("\nReset settings to default.");
+        if (ImGui.Button("Clear Settings"))
+        {
+            Program.ClearSettings(true);
         }
 
         ImGui.Text("\nDo all of the above.");


### PR DESCRIPTION
This makes the "Clear Prefix" button first, followed by "Clear Tools" and "Clear Dalamud", all of which are more likely to be needed that "Clear Settings". "Clear All" remains at the bottom.