### PR TITLE
fix: console spamming "gamemodeauto:"

### DIFF
--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -29,7 +29,7 @@ public class SettingsTabWine : SettingsTab
                 CheckVisibility = () => RuntimeInformation.IsOSPlatform(OSPlatform.Linux),
                 CheckValidity = b =>
                 {
-                    if (b == true && !CoreEnvironmentSettings.GameModeInstalled)
+                    if (b == true && !CoreEnvironmentSettings.IsGameModeInstalled())
                         return "GameMode was not detected on your system.";
                     return null;
                 }

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -29,10 +29,8 @@ public class SettingsTabWine : SettingsTab
                 CheckVisibility = () => RuntimeInformation.IsOSPlatform(OSPlatform.Linux),
                 CheckValidity = b =>
                 {
-                    var handle = IntPtr.Zero;
-                    if (b == true && !NativeLibrary.TryLoad("libgamemodeauto.so.0", out handle))
+                    if (b == true && !CoreEnvironmentSettings.GameModeInstalled)
                         return "GameMode was not detected on your system.";
-                    NativeLibrary.Free(handle);
                     return null;
                 }
             },

--- a/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
+++ b/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
@@ -39,17 +39,20 @@ public static class CoreEnvironmentSettings
         return string.Join(separator, Array.FindAll<string>(dirty.Split(separator, StringSplitOptions.RemoveEmptyEntries), s => !s.Contains(badstring)));
     }
 
-    static public bool GameModeInstalled { get; }
+    static private bool? gameModeInstalled = null;
 
-    static CoreEnvironmentSettings()
-    {  
+    static public bool IsGameModeInstalled()
+    {
+        if (gameModeInstalled is not null)
+            return gameModeInstalled ?? false;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
             var handle = IntPtr.Zero;
-            GameModeInstalled = NativeLibrary.TryLoad("libgamemodeauto.so.0", out handle);
+            gameModeInstalled = NativeLibrary.TryLoad("libgamemodeauto.so.0", out handle);
             NativeLibrary.Free(handle);
         }
         else
-            GameModeInstalled = false;
+            gameModeInstalled = false;
+        return gameModeInstalled ?? false;
     }
 }

--- a/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
+++ b/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 
 namespace XIVLauncher.Core;
 
@@ -36,5 +37,19 @@ public static class CoreEnvironmentSettings
         string dirty = Environment.GetEnvironmentVariable(envvar) ?? "";
         if (badstring.Equals("")) return dirty;
         return string.Join(separator, Array.FindAll<string>(dirty.Split(separator, StringSplitOptions.RemoveEmptyEntries), s => !s.Contains(badstring)));
+    }
+
+    static public bool GameModeInstalled { get; }
+
+    static CoreEnvironmentSettings()
+    {  
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            var handle = IntPtr.Zero;
+            GameModeInstalled = NativeLibrary.TryLoad("libgamemodeauto.so.0", out handle);
+            NativeLibrary.Free(handle);
+        }
+        else
+            GameModeInstalled = false;
     }
 }


### PR DESCRIPTION
Move gamemode check to CoreEnvironmentSettings so it only gets called once per session. The check result will be stored in a static variable, and then that variable will be checked instead of trying to load the gamemode module every frame. This prevents the console from filling up with "gamemodeauto:" multiple times per second.