### PR TITLE
Update frontier URL and fix news handling.

### DIFF
--- a/src/XIVLauncher.Core/LauncherApp.cs
+++ b/src/XIVLauncher.Core/LauncherApp.cs
@@ -125,13 +125,13 @@ public class LauncherApp : Component
 
     private readonly Background background = new();
 
-    public LauncherApp(Storage storage, bool needsUpdateWarning)
+    public LauncherApp(Storage storage, bool needsUpdateWarning, string frontierUrl)
     {
         this.Storage = storage;
 
         this.Accounts = new AccountManager(this.Storage.GetFile("accounts.json"));
         this.UniqueIdCache = new CommonUniqueIdCache(this.Storage.GetFile("uidCache.json"));
-        this.Launcher = new Launcher(Program.Steam, UniqueIdCache, Program.CommonSettings);
+        this.Launcher = new Launcher(Program.Steam, UniqueIdCache, Program.CommonSettings, frontierUrl);
 
         this.mainPage = new MainPage(this);
         this.setPage = new SettingsPage(this);

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -64,6 +64,8 @@ class Program
     private static uint invalidationFrames = 0;
     private static Vector2 lastMousePosition;
 
+    private const string FRONTIER_FALLBACK = "https://launcher.finalfantasyxiv.com/v650/index.html?rc_lang={0}&time={1}";
+
     public static void Invalidate(uint frames = 100)
     {
         invalidationFrames = frames;
@@ -258,7 +260,7 @@ class Program
 
         needUpdate = CoreEnvironmentSettings.IsUpgrade ? true : needUpdate;
 
-        launcherApp = new LauncherApp(storage, needUpdate);
+        launcherApp = new LauncherApp(storage, needUpdate, FRONTIER_FALLBACK);
 
         Invalidate(20);
 


### PR DESCRIPTION
When [commit 050c3c4](https://github.com/goatcorp/FFXIVQuickLauncher/commit/050c3c4ddc8523549e615b9f9f4577c2798f28af) was added to XL, it broke XL.Core.
1. The frontier URL endpoint was changed, and the XL.Common launcher now requires a frontier URL. I made a quick and dirty hack to hardcode the lastest value of "https://launcher.finalfantasyxiv.com/v650/index.html?rc_lang={0}&time={1}". Considering the current default value of "https://launcher.finalfantasyxiv.com/v620/index.html?rc_lang={0}&time={1}" still works most of the time, this should work until 7.0.
2. Headline handling was changed from a single function to four. I adjusted the NewsFrame class to account for these changes.
