### PR TITLE
Add option to force C.utf locale

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -685,6 +685,13 @@ public class MainPage : Page
 
         IGameRunner runner;
 
+        // Dalamud Fix: Force C.utf8 to fix incorrect paths
+        if (App.Settings.FixLocale.Value && !System.OperatingSystem.IsWindows())
+        {
+            System.Environment.SetEnvironmentVariable("LC_ALL", "C.utf8");
+            System.Environment.SetEnvironmentVariable("LC_CTYPE", "C.utf8");
+        }
+        
         // Hack: Strip out gameoverlayrenderer.so entries from LD_PRELOAD
         if (App.Settings.FixLDP.Value)
         {

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -685,7 +685,7 @@ public class MainPage : Page
 
         IGameRunner runner;
 
-        // Dalamud Fix: Force C.utf8 to fix incorrect paths
+        // Hack: Force C.utf8 to fix incorrect unicode paths
         if (App.Settings.FixLocale.Value && !System.OperatingSystem.IsWindows())
         {
             System.Environment.SetEnvironmentVariable("LC_ALL", "C.utf8");

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
@@ -14,7 +14,7 @@ public class SettingsTabTroubleshooting : SettingsTab
     {
         new SettingsEntry<bool>("Hack: Disable gameoverlayrenderer.so", "Fixes some stuttering issues after 40+ minutes, but may affect steam overlay and input.", () => Program.Config.FixLDP ?? false, x => Program.Config.FixLDP = x),
         new SettingsEntry<bool>("Hack: XMODIFIERS=\"@im=null\"", "Fixes some mouse-related issues, some stuttering issues", () => Program.Config.FixIM ?? false, x => Program.Config.FixIM = x),
-        new SettingsEntry<bool>("Hack: Force locale to C.utf8", "Sets LC_ALL and LC_CTYPE to C.utf8. This can fix some issues with unusual unicode characters in file paths.", () => Program.Config.FixLocale ?? false, b => Program.Config.FixLocale = b),
+        new SettingsEntry<bool>("Hack: Force locale to C.utf8", "Sets LC_ALL and LC_CTYPE to C.utf8. This can fix some issues with non-Latin unicode characters in file paths.", () => Program.Config.FixLocale ?? false, b => Program.Config.FixLocale = b),
     };
     public override string Title => "Troubleshooting";
 

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
@@ -14,6 +14,7 @@ public class SettingsTabTroubleshooting : SettingsTab
     {
         new SettingsEntry<bool>("Hack: Disable gameoverlayrenderer.so", "Fixes some stuttering issues after 40+ minutes, but may affect steam overlay and input.", () => Program.Config.FixLDP ?? false, x => Program.Config.FixLDP = x),
         new SettingsEntry<bool>("Hack: XMODIFIERS=\"@im=null\"", "Fixes some mouse-related issues, some stuttering issues", () => Program.Config.FixIM ?? false, x => Program.Config.FixIM = x),
+        new SettingsEntry<bool>("Hack: Force locale to C.utf8", "Sets LC_ALL and LC_CTYPE to C.utf8. This can fix some issues with unusual unicode characters in file paths.", () => Program.Config.FixLocale ?? false, b => Program.Config.FixLocale = b),
     };
     public override string Title => "Troubleshooting";
 

--- a/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
+++ b/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
@@ -78,6 +78,8 @@ public interface ILauncherConfig
 
     public string? WineDebugVars { get; set; }
 
+    public bool? FixLocale { get; set; }
+
     public bool? FixLDP { get; set; }
 
     public bool? FixIM { get; set; }

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -128,6 +128,7 @@ class Program
 
         Config.FixLDP ??= false;
         Config.FixIM ??= false;
+        Config.FixLocale ??= false;
     }
 
     public const uint STEAM_APP_ID = 39210;


### PR DESCRIPTION
Adds an option to the troubleshooting tab to force LC_ALL and LC_CTYPE to C.utf. This can fix some issues with non-Latin characters being rendered or saved incorrectly if the system's LANG is set to a non-utf8 value. Not all linux distros properly set LANG or other locale variables; the Steam deck in particular seems to use a non-utf8 value.