### PR TITLE
Fix locale hack 2: Now detects correct C.utf format

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -686,10 +686,10 @@ public class MainPage : Page
         IGameRunner runner;
 
         // Hack: Force C.utf8 to fix incorrect unicode paths
-        if (App.Settings.FixLocale.Value && !System.OperatingSystem.IsWindows())
+        if (App.Settings.FixLocale.Value && !string.IsNullOrEmpty(Program.Locale) && !System.OperatingSystem.IsWindows())
         {
-            System.Environment.SetEnvironmentVariable("LC_ALL", "C.utf8");
-            System.Environment.SetEnvironmentVariable("LC_CTYPE", "C.utf8");
+            System.Environment.SetEnvironmentVariable("LC_ALL", Program.Locale);
+            System.Environment.SetEnvironmentVariable("LC_CTYPE", Program.Locale);
         }
         
         // Hack: Strip out gameoverlayrenderer.so entries from LD_PRELOAD

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -686,10 +686,10 @@ public class MainPage : Page
         IGameRunner runner;
 
         // Hack: Force C.utf8 to fix incorrect unicode paths
-        if (App.Settings.FixLocale.Value && !string.IsNullOrEmpty(Program.Locale) && !System.OperatingSystem.IsWindows())
+        if (App.Settings.FixLocale.Value && !string.IsNullOrEmpty(Program.CType) && !System.OperatingSystem.IsWindows())
         {
-            System.Environment.SetEnvironmentVariable("LC_ALL", Program.Locale);
-            System.Environment.SetEnvironmentVariable("LC_CTYPE", Program.Locale);
+            System.Environment.SetEnvironmentVariable("LC_ALL", Program.CType);
+            System.Environment.SetEnvironmentVariable("LC_CTYPE", Program.CType);
         }
         
         // Hack: Strip out gameoverlayrenderer.so entries from LD_PRELOAD

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -686,7 +686,7 @@ public class MainPage : Page
         IGameRunner runner;
 
         // Hack: Force C.utf8 to fix incorrect unicode paths
-        if (App.Settings.FixLocale.Value && !string.IsNullOrEmpty(Program.CType) && !System.OperatingSystem.IsWindows())
+        if (App.Settings.FixLocale.Value && !string.IsNullOrEmpty(Program.CType))
         {
             System.Environment.SetEnvironmentVariable("LC_ALL", Program.CType);
             System.Environment.SetEnvironmentVariable("LC_CTYPE", Program.CType);

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
@@ -9,12 +9,14 @@ using XIVLauncher.Core;
 namespace XIVLauncher.Core.Components.SettingsPage.Tabs;
 
 public class SettingsTabTroubleshooting : SettingsTab
-{
+{   
     public override SettingsEntry[] Entries { get; } =
     {
         new SettingsEntry<bool>("Hack: Disable gameoverlayrenderer.so", "Fixes some stuttering issues after 40+ minutes, but may affect steam overlay and input.", () => Program.Config.FixLDP ?? false, x => Program.Config.FixLDP = x),
         new SettingsEntry<bool>("Hack: XMODIFIERS=\"@im=null\"", "Fixes some mouse-related issues, some stuttering issues", () => Program.Config.FixIM ?? false, x => Program.Config.FixIM = x),
-        new SettingsEntry<bool>("Hack: Force locale to C.utf8", "Sets LC_ALL and LC_CTYPE to C.utf8. This can fix some issues with non-Latin unicode characters in file paths.", () => Program.Config.FixLocale ?? false, b => Program.Config.FixLocale = b),
+        new SettingsEntry<bool>($"Hack: Force locale to {(!string.IsNullOrEmpty(Program.Locale) ? Program.Locale : "C.UTF-8 (exact value depends on distro)")}",
+                                !string.IsNullOrEmpty(Program.Locale) ? $"Sets LC_ALL and LC_CTYPE to \"{Program.Locale}\". This can fix some issues with non-Latin unicode characters in file paths." : "Hack Disabled. Could not find a UTF-8 C locale. You may have to set LC_ALL manually if LANG is not a UTF-8 type.",
+                                () => Program.Config.FixLocale ?? false, b => Program.Config.FixLocale = b),
     };
     public override string Title => "Troubleshooting";
 

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
@@ -14,8 +14,8 @@ public class SettingsTabTroubleshooting : SettingsTab
     {
         new SettingsEntry<bool>("Hack: Disable gameoverlayrenderer.so", "Fixes some stuttering issues after 40+ minutes, but may affect steam overlay and input.", () => Program.Config.FixLDP ?? false, x => Program.Config.FixLDP = x),
         new SettingsEntry<bool>("Hack: XMODIFIERS=\"@im=null\"", "Fixes some mouse-related issues, some stuttering issues", () => Program.Config.FixIM ?? false, x => Program.Config.FixIM = x),
-        new SettingsEntry<bool>($"Hack: Force locale to {(!string.IsNullOrEmpty(Program.Locale) ? Program.Locale : "C.UTF-8 (exact value depends on distro)")}",
-                                !string.IsNullOrEmpty(Program.Locale) ? $"Sets LC_ALL and LC_CTYPE to \"{Program.Locale}\". This can fix some issues with non-Latin unicode characters in file paths." : "Hack Disabled. Could not find a UTF-8 C locale. You may have to set LC_ALL manually if LANG is not a UTF-8 type.",
+        new SettingsEntry<bool>($"Hack: Force locale to {(!string.IsNullOrEmpty(Program.CType) ? Program.CType : "C.UTF-8 (exact value depends on distro)")}",
+                                !string.IsNullOrEmpty(Program.CType) ? $"Sets LC_ALL and LC_CTYPE to \"{Program.CType}\". This can fix some issues with non-Latin unicode characters in file paths." : "Hack Disabled. Could not find a UTF-8 C locale. You may have to set LC_ALL manually if LANG is not a UTF-8 type.",
                                 () => Program.Config.FixLocale ?? false, b => Program.Config.FixLocale = b),
     };
     public override string Title => "Troubleshooting";

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
@@ -15,8 +15,17 @@ public class SettingsTabTroubleshooting : SettingsTab
         new SettingsEntry<bool>("Hack: Disable gameoverlayrenderer.so", "Fixes some stuttering issues after 40+ minutes, but may affect steam overlay and input.", () => Program.Config.FixLDP ?? false, x => Program.Config.FixLDP = x),
         new SettingsEntry<bool>("Hack: XMODIFIERS=\"@im=null\"", "Fixes some mouse-related issues, some stuttering issues", () => Program.Config.FixIM ?? false, x => Program.Config.FixIM = x),
         new SettingsEntry<bool>($"Hack: Force locale to {(!string.IsNullOrEmpty(Program.CType) ? Program.CType : "C.UTF-8 (exact value depends on distro)")}",
-                                !string.IsNullOrEmpty(Program.CType) ? $"Sets LC_ALL and LC_CTYPE to \"{Program.CType}\". This can fix some issues with non-Latin unicode characters in file paths." : "Hack Disabled. Could not find a UTF-8 C locale. You may have to set LC_ALL manually if LANG is not a UTF-8 type.",
-                                () => Program.Config.FixLocale ?? false, b => Program.Config.FixLocale = b),
+                                !string.IsNullOrEmpty(Program.CType) ? $"Sets LC_ALL and LC_CTYPE to \"{Program.CType}\". This can fix some issues with non-Latin unicode characters in file paths if LANG is not a UTF-8 type" : "Hack Disabled. Could not find a UTF-8 C locale. You may have to set LC_ALL manually if LANG is not a UTF-8 type.",
+                                () => Program.Config.FixLocale ?? false, b => Program.Config.FixLocale = b)
+        {
+            CheckWarning = b =>
+            {
+                var lang = CoreEnvironmentSettings.GetCleanEnvironmentVariable("LANG");
+                if (lang.ToUpper().Contains("UTF") && b)
+                    return $"Your locale is \"{lang}\". You probably don't need this hack.";
+                return null;
+            }
+        },
     };
     public override string Title => "Troubleshooting";
 

--- a/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
+++ b/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
@@ -40,8 +40,10 @@ public static class CoreEnvironmentSettings
         return string.Join(separator, Array.FindAll<string>(dirty.Split(separator, StringSplitOptions.RemoveEmptyEntries), s => !s.Contains(badstring)));
     }
 
-    public static string GetLocale()
+    public static string GetCType()
     {
+        if (System.OperatingSystem.IsWindows())
+            return "";
         var psi = new ProcessStartInfo("sh");
         psi.Arguments = "-c \"locale -a 2>/dev/null | grep -i utf\"";
         psi.RedirectStandardOutput = true;

--- a/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
+++ b/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics;
+using System.Globalization;
 
 namespace XIVLauncher.Core;
 
@@ -36,5 +38,18 @@ public static class CoreEnvironmentSettings
         string dirty = Environment.GetEnvironmentVariable(envvar) ?? "";
         if (badstring.Equals("")) return dirty;
         return string.Join(separator, Array.FindAll<string>(dirty.Split(separator, StringSplitOptions.RemoveEmptyEntries), s => !s.Contains(badstring)));
+    }
+
+    public static string GetLocale()
+    {
+        var psi = new ProcessStartInfo("sh");
+        psi.Arguments = "-c \"locale -a 2>/dev/null | grep -i utf\"";
+        psi.RedirectStandardOutput = true;
+
+        var proc = new Process();
+        proc.StartInfo = psi;
+        proc.Start();
+        var output = proc.StandardOutput.ReadToEnd().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        return Array.Find(output, s => s.ToUpper().StartsWith("C."));
     }
 }

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -66,6 +66,8 @@ class Program
 
     private const string FRONTIER_FALLBACK = "https://launcher.finalfantasyxiv.com/v650/index.html?rc_lang={0}&time={1}";
 
+    public static string Locale = CoreEnvironmentSettings.GetLocale();
+
     public static void Invalidate(uint frames = 100)
     {
         invalidationFrames = frames;

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -66,7 +66,7 @@ class Program
 
     private const string FRONTIER_FALLBACK = "https://launcher.finalfantasyxiv.com/v650/index.html?rc_lang={0}&time={1}";
 
-    public static string Locale = CoreEnvironmentSettings.GetLocale();
+    public static string CType = CoreEnvironmentSettings.GetCType();
 
     public static void Invalidate(uint frames = 100)
     {


### PR DESCRIPTION
Check for valid C locale by running process. Exact command is `sh -c "locale -a 2>/dev/null | grep -i utf"`, which should execute on any Unix system without throwing an error in dotnet. It then selects the first valid entry that starts with "C." (not case sensitive). This will deal with cases of C.utf8, C.UTF-8, c.utf-8, etc.

If there is no value for the Ctype, the hack will be disabled, and hack text will change to let the user know that they'll have to set it manually.

If the users's LANG is already set to a UTF-8 type and they enable the hack, it will warn that the hack probably isn't needed, but the hack will still function.