### PR TITLE
Add builds for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,5 +40,8 @@ jobs:
       - name: Dotnet Build (Fedora)
         run: dotnet publish -r linux-x64 --sc --configuration Release -p:DefineConstants=WINE_XIV_FEDORA_LINUX --no-restore -o ./dist/XIVLauncher.Core-fedora
 
+      - name: Dotnet Build (Windows)
+        run: dotnet publish -r win-x64 --sc --configuration Release --no-restore -o ./dist/XIVLauncher.Core-winx64
+
       - name: Dotnet Test
         run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         run: dotnet publish -r linux-x64 --sc --configuration Release -p:DefineConstants=WINE_XIV_FEDORA_LINUX --no-restore -o ./dist/XIVLauncher.Core-fedora
 
       - name: Dotnet Build (Windows)
-        run: dotnet publish -r win-x64 --sc --configuration Release -o ./dist/XIVLauncher.Core-winx64
+        run: dotnet publish -r win10-x64 --sc --configuration Release -o ./dist/XIVLauncher.Core-win10x64
 
       - name: Dotnet Test
         run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         run: dotnet publish -r linux-x64 --sc --configuration Release -p:DefineConstants=WINE_XIV_FEDORA_LINUX --no-restore -o ./dist/XIVLauncher.Core-fedora
 
       - name: Dotnet Build (Windows)
-        run: dotnet publish -r win-x64 --sc --configuration Release --no-restore -o ./dist/XIVLauncher.Core-winx64
+        run: dotnet publish -r win-x64 --sc --configuration Release -o ./dist/XIVLauncher.Core-winx64
 
       - name: Dotnet Test
         run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -68,6 +68,10 @@ jobs:
         working-directory: ./src/XIVLauncher.Core/
         run: dotnet publish -r linux-x64 --sc --configuration Release -p:DefineConstants=WINE_XIV_FEDORA_LINUX --no-restore -o ./dist/XIVLauncher.Core-fedora
 
+      - name: Dotnet Build (Windows)
+        working-directory: ./src/XIVLauncher.Core/
+        run: dotnet publish -r win-x64 --sc --configuration Release --no-restore -o ./dist/XIVLauncher.Core-winx64
+
       - name: Generate nuget-dependencies.json
         working-directory: ./src/XIVLauncher.Core/
         run: |
@@ -132,6 +136,7 @@ jobs:
           tar -czf ./dist/XIVLauncher.Core.tar.gz -C ./src/XIVLauncher.Core/dist/XIVLauncher.Core .
           tar -czf ./dist/XIVLauncher.Core-arch.tar.gz -C ./src/XIVLauncher.Core/dist/XIVLauncher.Core-arch .
           tar -czf ./dist/XIVLauncher.Core-fedora.tar.gz -C ./src/XIVLauncher.Core/dist/XIVLauncher.Core-fedora .
+		  zip -r ./dist/XIVLauncher.Core-winx64.zip /src/XIVLauncher.Core/dist/XIVLauncher.Core-winx64
 
       - name: Release on GitHub
         uses: softprops/action-gh-release@v1
@@ -143,3 +148,4 @@ jobs:
             ./dist/XIVLauncher.Core.tar.gz
             ./dist/XIVLauncher.Core-arch.tar.gz
             ./dist/XIVLauncher.Core-fedora.tar.gz
+			./dist/XIVLauncher.Core-winx64.zip

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -136,7 +136,7 @@ jobs:
           tar -czf ./dist/XIVLauncher.Core.tar.gz -C ./src/XIVLauncher.Core/dist/XIVLauncher.Core .
           tar -czf ./dist/XIVLauncher.Core-arch.tar.gz -C ./src/XIVLauncher.Core/dist/XIVLauncher.Core-arch .
           tar -czf ./dist/XIVLauncher.Core-fedora.tar.gz -C ./src/XIVLauncher.Core/dist/XIVLauncher.Core-fedora .
-		  zip -r ./dist/XIVLauncher.Core-winx64.zip /src/XIVLauncher.Core/dist/XIVLauncher.Core-winx64
+          zip -r ./dist/XIVLauncher.Core-winx64.zip /src/XIVLauncher.Core/dist/XIVLauncher.Core-winx64
 
       - name: Release on GitHub
         uses: softprops/action-gh-release@v1
@@ -148,4 +148,4 @@ jobs:
             ./dist/XIVLauncher.Core.tar.gz
             ./dist/XIVLauncher.Core-arch.tar.gz
             ./dist/XIVLauncher.Core-fedora.tar.gz
-			./dist/XIVLauncher.Core-winx64.zip
+            ./dist/XIVLauncher.Core-winx64.zip

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Dotnet Build (Windows)
         working-directory: ./src/XIVLauncher.Core/
-        run: dotnet publish -r win-x64 --sc --configuration Release --no-restore -o ./dist/XIVLauncher.Core-winx64
+        run: dotnet publish -r win10-x64 --sc --configuration Release -o ./dist/XIVLauncher.Core-win10x64
 
       - name: Generate nuget-dependencies.json
         working-directory: ./src/XIVLauncher.Core/
@@ -136,7 +136,7 @@ jobs:
           tar -czf ./dist/XIVLauncher.Core.tar.gz -C ./src/XIVLauncher.Core/dist/XIVLauncher.Core .
           tar -czf ./dist/XIVLauncher.Core-arch.tar.gz -C ./src/XIVLauncher.Core/dist/XIVLauncher.Core-arch .
           tar -czf ./dist/XIVLauncher.Core-fedora.tar.gz -C ./src/XIVLauncher.Core/dist/XIVLauncher.Core-fedora .
-          zip -r ./dist/XIVLauncher.Core-winx64.zip /src/XIVLauncher.Core/dist/XIVLauncher.Core-winx64
+          zip -r ./dist/XIVLauncher.Core-win10x64.zip /src/XIVLauncher.Core/dist/XIVLauncher.Core-win10x64
 
       - name: Release on GitHub
         uses: softprops/action-gh-release@v1
@@ -148,4 +148,4 @@ jobs:
             ./dist/XIVLauncher.Core.tar.gz
             ./dist/XIVLauncher.Core-arch.tar.gz
             ./dist/XIVLauncher.Core-fedora.tar.gz
-            ./dist/XIVLauncher.Core-winx64.zip
+            ./dist/XIVLauncher.Core-win10x64.zip


### PR DESCRIPTION
As XIVLauncher.Core is a cross-platform project, we should also be providing Windows builds, even if users should typically use the WPF application instead.

These can be used for testing and in rare troubleshooting circumstances where the user is unable to use the WPF application, like when SquirrelSetup constantly fails, AV exceptions aren't working, or if the machine has .Net Framework disabled/removed.
