### PR TITLE
Use stable upstream Veldrid release

### DIFF
--- a/src/XIVLauncher.Core/XIVLauncher.Core.csproj
+++ b/src/XIVLauncher.Core/XIVLauncher.Core.csproj
@@ -63,10 +63,10 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
-    <PackageReference Include="goaaats.Veldrid" Version="4.9.0-beta1-g70f642e82e" />
-    <PackageReference Include="goaaats.Veldrid.ImageSharp" Version="4.9.0-beta1-g70f642e82e" />
-    <PackageReference Include="goaaats.Veldrid.SDL2" Version="4.9.0-beta1-g70f642e82e" />
-    <PackageReference Include="goaaats.Veldrid.StartupUtilities" Version="4.9.0-beta1-g70f642e82e" />
+    <PackageReference Include="Veldrid" Version="4.9.0" />
+    <PackageReference Include="Veldrid.ImageSharp" Version="4.9.0" />
+    <PackageReference Include="Veldrid.SDL2" Version="4.9.0" />
+    <PackageReference Include="Veldrid.StartupUtilities" Version="4.9.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Includes a few extra fixes back from our beta version.
Might need some testing with the flatpak, if that is still resolving SDL as expected.