### PR TITLE
Saving when hidden config option is invalid + Local dalamud fixes

### DIFF
--- a/src/XIVLauncher.Core/Components/SettingsPage/SettingsPage.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/SettingsPage.cs
@@ -115,7 +115,7 @@ public class SettingsPage : Page
             ImGui.PushStyleVar(ImGuiStyleVar.FrameRounding, 100f);
             ImGui.PushFont(FontManager.IconFont);
 
-            var invalid = this.tabs.Any(x => x.Entries.Any(y => !y.IsValid));
+            var invalid = this.tabs.Any(x => x.Entries.Any(y => y.IsVisible && !y.IsValid));
             if (invalid)
             {
                 ImGui.BeginDisabled();

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDalamud.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDalamud.cs
@@ -40,13 +40,17 @@ public class SettingsTabDalamud : SettingsTab
             new SettingsEntry<DirectoryInfo>("Manual Injection Path", "The path to the local version of Dalamud where Dalamud.Injector.exe is located", () => Program.Config.DalamudManualInjectPath, (input) =>
             {
                 Program.Config.DalamudManualInjectPath = input;
-                Program.DalamudUpdater.RunnerOverride = new FileInfo(Path.Combine(input!.FullName, Program.DALAMUD_INJECTOR_NAME));
+                if (input is null) {
+                    Program.DalamudUpdater.RunnerOverride = null;
+                    return;
+                }
+                Program.DalamudUpdater.RunnerOverride = new FileInfo(Path.Combine(input.FullName, Program.DALAMUD_INJECTOR_NAME));
             })
             {
-                CheckVisibility = () => enableManualInjection.Value,
+            CheckVisibility = () => enableManualInjection.Value,
                 CheckValidity = input =>
                 {
-                     if (input is null || !input.Exists)
+                    if (input is null || !input.Exists)
                     {
                         return "There is no directory at that path.";
                     }

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDalamud.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDalamud.cs
@@ -47,7 +47,7 @@ public class SettingsTabDalamud : SettingsTab
                 Program.DalamudUpdater.RunnerOverride = new FileInfo(Path.Combine(input.FullName, Program.DALAMUD_INJECTOR_NAME));
             })
             {
-            CheckVisibility = () => enableManualInjection.Value,
+                CheckVisibility = () => enableManualInjection.Value,
                 CheckValidity = input =>
                 {
                     if (input is null || !input.Exists)

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDalamud.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDalamud.cs
@@ -39,8 +39,9 @@ public class SettingsTabDalamud : SettingsTab
 
             new SettingsEntry<DirectoryInfo>("Manual Injection Path", "The path to the local version of Dalamud where Dalamud.Injector.exe is located", () => Program.Config.DalamudManualInjectPath, (input) =>
             {
+                if (enableManualInjection.Value == false) return;
                 Program.Config.DalamudManualInjectPath = input;
-                Program.DalamudUpdater.RunnerOverride = input is null ? null : new FileInfo(Path.Combine(input.FullName, Program.DALAMUD_INJECTOR_NAME));
+                Program.DalamudUpdater.RunnerOverride = new FileInfo(Path.Combine(input.FullName, Program.DALAMUD_INJECTOR_NAME));
             })
             {
                 CheckVisibility = () => enableManualInjection.Value,

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDalamud.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDalamud.cs
@@ -40,11 +40,7 @@ public class SettingsTabDalamud : SettingsTab
             new SettingsEntry<DirectoryInfo>("Manual Injection Path", "The path to the local version of Dalamud where Dalamud.Injector.exe is located", () => Program.Config.DalamudManualInjectPath, (input) =>
             {
                 Program.Config.DalamudManualInjectPath = input;
-                if (input is null) {
-                    Program.DalamudUpdater.RunnerOverride = null;
-                    return;
-                }
-                Program.DalamudUpdater.RunnerOverride = new FileInfo(Path.Combine(input.FullName, Program.DALAMUD_INJECTOR_NAME));
+                Program.DalamudUpdater.RunnerOverride = input is null ? null : new FileInfo(Path.Combine(input.FullName, Program.DALAMUD_INJECTOR_NAME));
             })
             {
                 CheckVisibility = () => enableManualInjection.Value,

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDalamud.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDalamud.cs
@@ -29,26 +29,28 @@ public class SettingsTabDalamud : SettingsTab
                      return;
                  }
 
-                 if (Directory.Exists(Program.Config.DalamudManualInjectPath) && Directory.GetFiles(Program.Config.DalamudManualInjectPath).FirstOrDefault(x => x == "Dalamud.Injector.exe") is not null)
+                 if (Program.Config.DalamudManualInjectPath is not null &&
+                    Program.Config.DalamudManualInjectPath.Exists &&
+                    Program.Config.DalamudManualInjectPath.GetFiles().FirstOrDefault(x => x.Name == Program.DALAMUD_INJECTOR_NAME) is not null)
                  {
-                     Program.DalamudUpdater.RunnerOverride = new FileInfo(Path.Combine(Program.Config.DalamudManualInjectPath, Program.DALAMUD_INJECTOR_NAME));
-                 }
-             }),
+                     Program.DalamudUpdater.RunnerOverride = new FileInfo(Path.Combine(Program.Config.DalamudManualInjectPath.FullName, Program.DALAMUD_INJECTOR_NAME));
+                }
+            }),
 
-            new SettingsEntry<string>("Manual Injection Path", "The path to the local version of Dalamud where Dalamud.Injector.exe is located", () => Program.Config.DalamudManualInjectPath, (input) =>
+            new SettingsEntry<DirectoryInfo>("Manual Injection Path", "The path to the local version of Dalamud where Dalamud.Injector.exe is located", () => Program.Config.DalamudManualInjectPath, (input) =>
             {
                 Program.Config.DalamudManualInjectPath = input;
-                Program.DalamudUpdater.RunnerOverride = new FileInfo(Path.Combine(input, Program.DALAMUD_INJECTOR_NAME));
+                Program.DalamudUpdater.RunnerOverride = new FileInfo(Path.Combine(input!.FullName, Program.DALAMUD_INJECTOR_NAME));
             })
             {
-                CheckVisibility = () => enableManualInjection.Value == true,
+                CheckVisibility = () => enableManualInjection.Value,
                 CheckValidity = input =>
                 {
-                    if (!Directory.Exists(input))
+                     if (input is null || !input.Exists)
                     {
                         return "There is no directory at that path.";
                     }
-                    if (Directory.GetFiles(input).FirstOrDefault(x => x == Program.DALAMUD_INJECTOR_NAME) is not null)
+                    else if (input.GetFiles().FirstOrDefault(x => x.Name == Program.DALAMUD_INJECTOR_NAME) is null)
                     {
                         return "Dalamud.Injector.exe was not found inside of the provided directory.";
                     }

--- a/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
+++ b/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
@@ -94,7 +94,7 @@ public interface ILauncherConfig
 
     public DalamudLoadMethod? DalamudLoadMethod { get; set; }
     public bool? DalamudManualInjectionEnabled { get; set; }
-    public string? DalamudManualInjectPath { get; set; }
+    public DirectoryInfo? DalamudManualInjectPath { get; set; }
 
     public int DalamudLoadDelay { get; set; }
 

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -151,18 +151,16 @@ class Program
     /// <returns>A <see cref="DalamudUpdater"/> instance.</returns>
     private static DalamudUpdater CreateDalamudUpdater()
     {
-        if (Config.DalamudManualInjectionEnabled == true &&
-            Directory.Exists(Config.DalamudManualInjectPath) &&
-            Directory.GetFiles(Config.DalamudManualInjectPath).FirstOrDefault(f => f == DALAMUD_INJECTOR_NAME) is not null)
+        if (Config.DalamudManualInjectPath is not null &&
+           Config.DalamudManualInjectPath.Exists &&
+           Config.DalamudManualInjectPath.GetFiles().FirstOrDefault(x => x.Name == DALAMUD_INJECTOR_NAME) is not null)
         {
-            var updater = new DalamudUpdater(new DirectoryInfo(Config.DalamudManualInjectPath), storage.GetFolder("runtime"), storage.GetFolder("dalamudAssets"), storage.Root, null, null)
+            return new DalamudUpdater(Config.DalamudManualInjectPath, storage.GetFolder("runtime"), storage.GetFolder("dalamudAssets"), storage.Root, null, null)
             {
                 Overlay = DalamudLoadInfo,
+                RunnerOverride = new FileInfo(Path.Combine(Config.DalamudManualInjectPath.FullName, DALAMUD_INJECTOR_NAME))
             };
-            DalamudUpdater.RunnerOverride = new FileInfo(Path.Combine(Config.DalamudManualInjectPath, DALAMUD_INJECTOR_NAME));
-            return updater;
         }
-
         return new DalamudUpdater(storage.GetFolder("dalamud"), storage.GetFolder("runtime"), storage.GetFolder("dalamudAssets"), storage.Root, null, null)
         {
             Overlay = DalamudLoadInfo,


### PR DESCRIPTION
Also changes the manual Dalamud injection path to be `DirectoryInfo` instead of a `string`.

It also fixes some validation around the manual injection path in the first place to make it actually save when valid.