### PR TITLE
Support bootver killswitch and dynamic frontier urls

### DIFF
--- a/src/XIVLauncher.Core/LauncherApp.cs
+++ b/src/XIVLauncher.Core/LauncherApp.cs
@@ -127,8 +127,6 @@ public class LauncherApp : Component
 
     private readonly Background background = new();
 
-    private readonly string? cutOffBootver;
-
     public LauncherApp(Storage storage, bool needsUpdateWarning, string frontierUrl, string? cutOffBootver)
     {
         this.Storage = storage;
@@ -136,7 +134,6 @@ public class LauncherApp : Component
         this.Accounts = new AccountManager(this.Storage.GetFile("accounts.json"));
         this.UniqueIdCache = new CommonUniqueIdCache(this.Storage.GetFile("uidCache.json"));
         this.Launcher = new Launcher(Program.Steam, UniqueIdCache, Program.CommonSettings, frontierUrl);
-        this.cutOffBootver = cutOffBootver;
 
         this.mainPage = new MainPage(this);
         this.setPage = new SettingsPage(this);
@@ -146,7 +143,7 @@ public class LauncherApp : Component
         this.updateWarnPage = new UpdateWarnPage(this);
         this.steamDeckPromptPage = new SteamDeckPromptPage(this);
 
-        if (!string.IsNullOrEmpty(this.cutOffBootver))
+        if (!string.IsNullOrEmpty(cutOffBootver))
         {
             var bootver = SeVersion.Parse(Repository.Boot.GetVer(Program.Config.GamePath));
             var cutoff = SeVersion.Parse(cutOffBootver);

--- a/src/XIVLauncher.Core/LauncherClientConfig.cs
+++ b/src/XIVLauncher.Core/LauncherClientConfig.cs
@@ -1,0 +1,40 @@
+
+using System.Net.Http.Json;
+using Serilog;
+
+namespace XIVLauncher.Core;
+
+
+/// <summary>
+///     Represents a response from Kamori's GetLauncherClientConfig endpoint.
+/// </summary>
+public readonly struct LauncherClientConfig
+{
+    private const string LAUNCHER_CONFIG_URL = "https://kamori.goats.dev/Launcher/GetLauncherClientConfig";
+    private const string FRONTIER_FALLBACK = "https://launcher.finalfantasyxiv.com/v650/index.html?rc_lang={0}&time={1}";
+
+    public required string frontierUrl { get; init; }
+    public string? cutOffBootver { get; init; }
+    public uint flags { get; init; }
+
+    public static async Task<LauncherClientConfig> Fetch()
+    {
+        try
+        {
+            using var client = new HttpClient()
+            {
+                Timeout = TimeSpan.FromSeconds(5),
+            };
+            return await client.GetFromJsonAsync<LauncherClientConfig>(LAUNCHER_CONFIG_URL).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Could not obtain LauncherClientConfig");
+            return new LauncherClientConfig()
+            {
+                frontierUrl = FRONTIER_FALLBACK,
+            };
+        }
+    }
+}
+

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -63,7 +63,6 @@ class Program
     private static uint invalidationFrames = 0;
     private static Vector2 lastMousePosition;
 
-    private const string FRONTIER_FALLBACK = "https://launcher.finalfantasyxiv.com/v650/index.html?rc_lang={0}&time={1}";
 
     public static string CType = CoreEnvironmentSettings.GetCType();
 
@@ -292,7 +291,8 @@ class Program
 
         needUpdate = CoreEnvironmentSettings.IsUpgrade ? true : needUpdate;
 
-        launcherApp = new LauncherApp(storage, needUpdate, FRONTIER_FALLBACK);
+        var launcherClientConfig = LauncherClientConfig.Fetch().GetAwaiter().GetResult();
+        launcherApp = new LauncherApp(storage, needUpdate, launcherClientConfig.frontierUrl, launcherClientConfig.cutOffBootver);
 
         Invalidate(20);
 


### PR DESCRIPTION
A bit hacked together very late at night but this is enough to prevent XLCore from being usable when the bootver killswitch is set. 

I also took the opportunity to make fetching frontier URLs dynamic since they come from the same Kamori endpoint.