### PR TITLE
Stop news titles from being interpreted as format strings

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/NewsFrame.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/NewsFrame.cs
@@ -94,7 +94,7 @@ public class NewsFrame : Component
 
                 void ShowNewsEntry(News newsEntry)
                 {
-                    ImGui.Text(newsEntry.Title);
+                    ImGui.TextUnformatted(newsEntry.Title);
 
                     if (ImGui.IsItemClicked(ImGuiMouseButton.Left) && !string.IsNullOrEmpty(newsEntry.Url))
                     {


### PR DESCRIPTION
As of this PR, one of the current news titles contains a "%", and, since the titles are currently being interpreted as a format string, it appears as junk in the middle of the title.