### PR TITLE
fix: only inject path if manual injection enabled

### DIFF
--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDalamud.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDalamud.cs
@@ -20,20 +20,20 @@ public class SettingsTabDalamud : SettingsTab
             new NumericSettingsEntry("Injection Delay (ms)", "Choose how long to wait after the game has loaded before injecting.", () => Program.Config.DalamudLoadDelay, delay => Program.Config.DalamudLoadDelay = delay, 0, int.MaxValue, 1000),
 
             enableManualInjection = new SettingsEntry<bool>("Enable Manual Injection", "Use a local build of Dalamud instead of the automatically provided one (For developers only!)", () => Program.Config.DalamudManualInjectionEnabled ?? false, (enabled) =>
-             {
-                 Program.Config.DalamudManualInjectionEnabled = enabled;
+            {
+                Program.Config.DalamudManualInjectionEnabled = enabled;
 
-                 if (!enabled)
-                 {
-                     Program.DalamudUpdater.RunnerOverride = null;
-                     return;
-                 }
+                if (!enabled)
+                {
+                    Program.DalamudUpdater.RunnerOverride = null;
+                    return;
+                }
 
-                 if (Program.Config.DalamudManualInjectPath is not null &&
+                if (Program.Config.DalamudManualInjectPath is not null &&
                     Program.Config.DalamudManualInjectPath.Exists &&
                     Program.Config.DalamudManualInjectPath.GetFiles().FirstOrDefault(x => x.Name == Program.DALAMUD_INJECTOR_NAME) is not null)
-                 {
-                     Program.DalamudUpdater.RunnerOverride = new FileInfo(Path.Combine(Program.Config.DalamudManualInjectPath.FullName, Program.DALAMUD_INJECTOR_NAME));
+                {
+                    Program.DalamudUpdater.RunnerOverride = new FileInfo(Path.Combine(Program.Config.DalamudManualInjectPath.FullName, Program.DALAMUD_INJECTOR_NAME));
                 }
             }),
 

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -154,19 +154,18 @@ class Program
     /// <returns>A <see cref="DalamudUpdater"/> instance.</returns>
     private static DalamudUpdater CreateDalamudUpdater()
     {
+        FileInfo runnerOverride = null;
         if (Config.DalamudManualInjectPath is not null &&
-           Config.DalamudManualInjectPath.Exists &&
-           Config.DalamudManualInjectPath.GetFiles().FirstOrDefault(x => x.Name == DALAMUD_INJECTOR_NAME) is not null)
+            Config.DalamudManualInjectionEnabled == true &&
+            Config.DalamudManualInjectPath.Exists &&
+            Config.DalamudManualInjectPath.GetFiles().FirstOrDefault(x => x.Name == DALAMUD_INJECTOR_NAME) is not null)
         {
-            return new DalamudUpdater(Config.DalamudManualInjectPath, storage.GetFolder("runtime"), storage.GetFolder("dalamudAssets"), storage.Root, null, null)
-            {
-                Overlay = DalamudLoadInfo,
-                RunnerOverride = new FileInfo(Path.Combine(Config.DalamudManualInjectPath.FullName, DALAMUD_INJECTOR_NAME))
-            };
+            runnerOverride = new FileInfo(Path.Combine(Config.DalamudManualInjectPath.FullName, DALAMUD_INJECTOR_NAME));
         }
         return new DalamudUpdater(storage.GetFolder("dalamud"), storage.GetFolder("runtime"), storage.GetFolder("dalamudAssets"), storage.Root, null, null)
         {
             Overlay = DalamudLoadInfo,
+            RunnerOverride = runnerOverride
         };
     }
 


### PR DESCRIPTION
Fix a bug where the  manual injection dalamud path was being used even if it was disabled. Basically, the CreateDalamudUpdater function didn't check DalamudManualInjectionEnabled before creating the updater, so as long as there was a valid path in DalamudManualInjectionPath it would use it. Fixes Issue #148