### PR TITLE
fix: CheckBootVersion returns zero-length array instead of null

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -938,7 +938,7 @@ public class MainPage : Page
                 return false;
             }
 
-            if (bootPatches == null)
+            if (bootPatches.Length == 0)
                 return true;
 
             return await TryHandlePatchAsync(Repository.Boot, bootPatches, "").ConfigureAwait(false);


### PR DESCRIPTION
Fix for API change in Launcher.CheckBootVersion(). It now returns a zero-length array instead of null if there are no patches.