### PR TITLE
Add compat tool environment vars and handling.

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -676,6 +676,17 @@ public class MainPage : Page
 
         IGameRunner runner;
 
+        // Set LD_PRELOAD to value of XL_PRELOAD if we're running as a steam compatibility tool.
+        // This check must be done before the FixLDP check so that it will still work.
+        if (CoreEnvironmentSettings.IsSteamCompatTool)
+        {
+            var ldpreload = System.Environment.GetEnvironmentVariable("LD_PRELOAD") ?? "";
+            var xlpreload = System.Environment.GetEnvironmentVariable("XL_PRELOAD") ?? "";
+            ldpreload = (ldpreload + ":" + xlpreload).Trim(':');
+            if (!string.IsNullOrEmpty(ldpreload))
+                System.Environment.SetEnvironmentVariable("LD_PRELOAD", ldpreload);
+        }
+
         // Hack: Force C.utf8 to fix incorrect unicode paths
         if (App.Settings.FixLocale == true && !string.IsNullOrEmpty(Program.CType))
         {

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
@@ -33,7 +33,10 @@ public class SettingsTabGame : SettingsTab
         new SettingsEntry<DpiAwareness>("Game DPI Awareness", "Select the game's DPI Awareness. Change this if the game's scaling looks wrong.", () => Program.Config.DpiAwareness ?? DpiAwareness.Unaware, x => Program.Config.DpiAwareness = x),
         new SettingsEntry<bool>("Free Trial Account", "Check this if you are using a free trial account.", () => Program.Config.IsFt ?? false, x => Program.Config.IsFt = x),
         new SettingsEntry<bool>("Use XIVLauncher authenticator/OTP macros", "Check this if you want to use the XIVLauncher authenticator app or macros.", () => Program.Config.IsOtpServer ?? false, x => Program.Config.IsOtpServer = x),
-        new SettingsEntry<bool>("Ignore Steam", "Check this if you do not want XIVLauncher to communicate with Steam (Requires Restart).", () => Program.Config.IsIgnoringSteam ?? false, x => Program.Config.IsIgnoringSteam = x),
+        new SettingsEntry<bool>("Ignore Steam", "Check this if you do not want XIVLauncher to communicate with Steam (Requires Restart).", () => Program.Config.IsIgnoringSteam ?? false, x => Program.Config.IsIgnoringSteam = x)
+        {
+            CheckVisibility = () => !CoreEnvironmentSettings.IsSteamCompatTool,
+        },
         new SettingsEntry<bool>("Use Experimental UID Cache", "Tries to save your login token for the next start. Can result in launching with expired sessions.\nDisable if receiving FFXIV error 1012 or 500X.", () => Program.Config.IsUidCacheEnabled ?? false, x => Program.Config.IsUidCacheEnabled = x),
     };
 

--- a/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
+++ b/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
@@ -15,6 +15,7 @@ public static class CoreEnvironmentSettings
     public static bool ClearLogs => CheckEnvBool("XL_CLEAR_LOGS");
     public static bool ClearAll => CheckEnvBool("XL_CLEAR_ALL");
     public static bool? UseSteam => CheckEnvBoolOrNull("XL_USE_STEAM"); // Fix for Steam Deck users who lock themselves out
+    public static bool IsSteamCompatTool => CheckEnvBool("XL_SCT");
 
     private static bool CheckEnvBool(string key)
     {

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -225,7 +225,7 @@ class Program
                 default:
                     throw new PlatformNotSupportedException();
             }
-            if (!Config.IsIgnoringSteam ?? true)
+            if (Config.IsIgnoringSteam != true || CoreEnvironmentSettings.IsSteamCompatTool)
             {
                 try
                 {


### PR DESCRIPTION
Since Blooym is making an external install program for a steam compatibility tool (and I've already got a preliminary implementation [here](https://github.com/rankynbass/RBLocalInstaller)), there's a workaround that needs to be implemented.

If Steam Overlay is on in desktop mode, the launcher will sometimes become a blocky, unreadable mess:
![FFXIV_Steam_Overlay_Bug](https://github.com/goatcorp/XIVLauncher.Core/assets/109918887/5d5b891e-891c-4083-9e18-20ec900a9b00)

To fix this, in the compat tool launch script, we'll set `XL_SCT=1`, and `XL_PRELOAD=$LD_PRELOAD`. and then `unset LD_PRELOAD`.

This patch adds handling for those environment variables, so that LD_PRELOAD can be re-added to the launched wine environment. This *will* enable steam overlay.