### PR TITLE
Pull in the fixed game repair function from 6.4.1

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -1049,7 +1049,7 @@ public class MainPage : Page
             finally
             {
                 token.Cancel();
-                statusThread.Join(3000);
+                statusThread.Join(TimeSpan.FromMilliseconds(1000));
             }
 
             return true;
@@ -1149,7 +1149,7 @@ public class MainPage : Page
         Log.Information("STARTING REPAIR");
 
         // TODO: bundle the PatchInstaller with xl-core on Windows and run this remotely
-        using var verify = new PatchVerifier(Program.CommonSettings, loginResult, 20, loginResult.OauthLogin.MaxExpansion, false);
+        using var verify = new PatchVerifier(Program.CommonSettings, loginResult, TimeSpan.FromMilliseconds(100), loginResult.OauthLogin.MaxExpansion, false);
 
         for (bool doVerify = true; doVerify;)
         {


### PR DESCRIPTION
Had to update MainPage.cs. Two functions changed from using int to TimeSpan. Values are up for debate, since I'm not entirely sure what they represented before. But these seem to work just fine.