### PR TITLE
Add XL_APPID as an override for using Free Trial

### DIFF
--- a/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
+++ b/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
@@ -16,7 +16,7 @@ public static class CoreEnvironmentSettings
     public static bool ClearAll => CheckEnvBool("XL_CLEAR_ALL");
     public static bool? UseSteam => CheckEnvBoolOrNull("XL_USE_STEAM"); // Fix for Steam Deck users who lock themselves out
     public static bool IsSteamCompatTool => CheckEnvBool("XL_SCT");
-    public static int AltAppID => GetAltAppId(System.Environment.GetEnvironmentVariable("XL_APPID"));
+    public static uint AltAppID => GetAltAppId(System.Environment.GetEnvironmentVariable("XL_APPID"));
 
     private static bool CheckEnvBool(string key)
     {
@@ -40,13 +40,13 @@ public static class CoreEnvironmentSettings
         return string.Join(separator, Array.FindAll<string>(dirty.Split(separator, StringSplitOptions.RemoveEmptyEntries), s => !s.Contains(badstring)));
     }
 
-    public static int GetAltAppId(string? appid)
+    public static uint GetAltAppId(string? appid)
     {
-        int result;
-        if (int.TryParse(appid, out result))
-            return result;
-        else
-            return -1;
+        uint result;
+        uint.TryParse(appid, out result);
+        
+        // Will return 0 if appid is invalid (or zero).
+        return result;
     }
 
     public static string GetCType()

--- a/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
+++ b/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
@@ -42,8 +42,7 @@ public static class CoreEnvironmentSettings
 
     public static uint GetAltAppId(string? appid)
     {
-        uint result;
-        uint.TryParse(appid, out result);
+        uint.TryParse(appid, out var result);
         
         // Will return 0 if appid is invalid (or zero).
         return result;

--- a/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
+++ b/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
@@ -16,6 +16,7 @@ public static class CoreEnvironmentSettings
     public static bool ClearAll => CheckEnvBool("XL_CLEAR_ALL");
     public static bool? UseSteam => CheckEnvBoolOrNull("XL_USE_STEAM"); // Fix for Steam Deck users who lock themselves out
     public static bool IsSteamCompatTool => CheckEnvBool("XL_SCT");
+    public static int AltAppID => GetAltAppId(System.Environment.GetEnvironmentVariable("XL_APPID"));
 
     private static bool CheckEnvBool(string key)
     {
@@ -37,6 +38,15 @@ public static class CoreEnvironmentSettings
         string dirty = Environment.GetEnvironmentVariable(envvar) ?? "";
         if (badstring.Equals("", StringComparison.Ordinal)) return dirty;
         return string.Join(separator, Array.FindAll<string>(dirty.Split(separator, StringSplitOptions.RemoveEmptyEntries), s => !s.Contains(badstring)));
+    }
+
+    public static int GetAltAppId(string? appid)
+    {
+        int result;
+        if (int.TryParse(appid, out result))
+            return result;
+        else
+            return -1;
     }
 
     public static string GetCType()

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -196,9 +196,10 @@ class Program
 
         uint appId, altId;
         string appName, altName;
+        // AppId of 0 is invalid (though still a valid uint)
         if (CoreEnvironmentSettings.AltAppID > 0)
         {
-            appId = (uint)CoreEnvironmentSettings.AltAppID;
+            appId = CoreEnvironmentSettings.AltAppID;
             altId = STEAM_APP_ID_FT;
             appName = $"Override AppId={appId.ToString()}";
             altName = "FFXIV Free Trial";

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -198,7 +198,7 @@ class Program
         string appName, altName;
         if (CoreEnvironmentSettings.AltAppID > 0)
         {
-            appId = (uint)(int)CoreEnvironmentSettings.AltAppID;
+            appId = (uint)CoreEnvironmentSettings.AltAppID;
             altId = STEAM_APP_ID_FT;
             appName = $"Override AppId={appId.ToString()}";
             altName = "FFXIV Free Trial";

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -196,7 +196,14 @@ class Program
 
         uint appId, altId;
         string appName, altName;
-        if (Config.IsFt == true)
+        if (CoreEnvironmentSettings.AltAppID > 0)
+        {
+            appId = (uint)(int)CoreEnvironmentSettings.AltAppID;
+            altId = STEAM_APP_ID_FT;
+            appName = $"Override AppId={appId.ToString()}";
+            altName = "FFXIV Free Trial";
+        }
+        else if (Config.IsFt == true)
         {
             appId = STEAM_APP_ID_FT;
             altId = STEAM_APP_ID;


### PR DESCRIPTION
With the recent changes to the Free Trial / Demo, some users are having problems getting or keeping FFXIV Free Trial in their library. This allows the user to override the first AppID tried with some other number.

AppID will still fall back to the free trial if an invalid number is used, and if the value passed is not a number (or a number <= 0) it will be ignored.

Fun fact, using proton ids such as `XL_APPID=2805730` for proton 9.0 does work. Not sure that would be the best idea, however.