### PR TITLE
fix: Corrected log paths in PackGenerator to include dalamud logs

### DIFF
--- a/src/XIVLauncher.Core/Support/PackGenerator.cs
+++ b/src/XIVLauncher.Core/Support/PackGenerator.cs
@@ -20,11 +20,11 @@ namespace XIVLauncher.Core.Support
             troubleEntry.Close();
 
             var xlLogFile = new FileInfo(Path.Combine(storage.GetFolder("logs").FullName, "launcher.log"));
-            var patcherLogFile = new FileInfo(Path.Combine(storage.Root.FullName, "patcher.log"));
-            var dalamudLogFile = new FileInfo(Path.Combine(storage.Root.FullName, "dalamud.log"));
-            var dalamudInjectorLogFile = new FileInfo(Path.Combine(storage.Root.FullName, "dalamud.injector.log"));
-            var dalamudBootLogFile = new FileInfo(Path.Combine(storage.Root.FullName, "dalamud.boot.log"));
-            var ariaLogFile = new FileInfo(Path.Combine(storage.Root.FullName, "aria.log"));
+            var patcherLogFile = new FileInfo(Path.Combine(storage.GetFolder("logs").FullName, "patcher.log"));
+            var dalamudLogFile = new FileInfo(Path.Combine(storage.GetFolder("logs").FullName, "dalamud.log"));
+            var dalamudInjectorLogFile = new FileInfo(Path.Combine(storage.GetFolder("logs").FullName, "dalamud.injector.log"));
+            var dalamudBootLogFile = new FileInfo(Path.Combine(storage.GetFolder("logs").FullName, "dalamud.boot.log"));
+            var ariaLogFile = new FileInfo(Path.Combine(storage.GetFolder("logs").FullName, "aria.log"));
             var wineLogFile = new FileInfo(Path.Combine(storage.GetFolder("logs").FullName, "wine.log"));
 
             AddIfExist(xlLogFile, archive);


### PR DESCRIPTION
The logs are all now in the logs/ folder, but the pack generator code didn't get corrected. As a result, tspacks didn't include dalamud logs. This PR fixes those paths so all the logs will be properly included.

As an aside, I'm not sure where patcher.log and aria.log actually end up, or if they even get generated for xlcore. They don't end up in ~/.xlcore or ~/.xlcore/logs. I've set them to ~/.xlcore/logs as well.