### PR TITLE
Improve steam initialization and game launch feedback

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -821,15 +821,6 @@ public class MainPage : Page
             throw new NotImplementedException();
         }
 
-        if (!Program.IsSteamDeckHardware)
-        {
-            Hide();
-        }
-        else
-        {
-            App.State = LauncherApp.LauncherState.SteamDeckPrompt;
-        }
-
         // We won't do any sanity checks here anymore, since that should be handled in StartLogin
         var launchedProcess = App.Launcher.LaunchGame(runner,
             loginResult.UniqueId,
@@ -841,6 +832,17 @@ public class MainPage : Page
             App.Settings.ClientLanguage.GetValueOrDefault(ClientLanguage.English),
             App.Settings.IsEncryptArgs.GetValueOrDefault(true),
             App.Settings.DpiAwareness.GetValueOrDefault(DpiAwareness.Unaware));
+
+        // Hide the launcher if not Steam Deck or if using as a compatibility tool (XLM)
+        // Show the Steam Deck prompt if on steam deck and not using as a compatibility tool
+        if (!Program.IsSteamDeckHardware || CoreEnvironmentSettings.IsSteamCompatTool)
+        {
+            Hide();
+        }
+        else
+        {
+            App.State = LauncherApp.LauncherState.SteamDeckPrompt;
+        }
 
         if (launchedProcess == null)
         {

--- a/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
+++ b/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
@@ -16,7 +16,8 @@ public static class CoreEnvironmentSettings
     public static bool ClearAll => CheckEnvBool("XL_CLEAR_ALL");
     public static bool? UseSteam => CheckEnvBoolOrNull("XL_USE_STEAM"); // Fix for Steam Deck users who lock themselves out
     public static bool IsSteamCompatTool => CheckEnvBool("XL_SCT");
-    public static uint AltAppID => GetAltAppId(System.Environment.GetEnvironmentVariable("XL_APPID"));
+    public static uint SteamAppId => GetAppId(System.Environment.GetEnvironmentVariable("SteamAppId"));
+    public static uint AltAppID => GetAppId(System.Environment.GetEnvironmentVariable("XL_APPID"));
 
     private static bool CheckEnvBool(string key)
     {
@@ -40,7 +41,7 @@ public static class CoreEnvironmentSettings
         return string.Join(separator, Array.FindAll<string>(dirty.Split(separator, StringSplitOptions.RemoveEmptyEntries), s => !s.Contains(badstring)));
     }
 
-    public static uint GetAltAppId(string? appid)
+    public static uint GetAppId(string? appid)
     {
         uint.TryParse(appid, out var result);
         

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -198,29 +198,25 @@ sealed class Program
 
         Loc.SetupWithFallbacks();
 
-        uint appId, altId;
-        string appName, altName;
-        // AppId of 0 is invalid (though still a valid uint)
-        if (CoreEnvironmentSettings.AltAppID > 0)
+        Dictionary<uint, string> apps = new Dictionary<uint, string>();
+        uint[] ignoredIds = { 0, STEAM_APP_ID, STEAM_APP_ID_FT};
+        if (!ignoredIds.Contains(CoreEnvironmentSettings.SteamAppId))
         {
-            appId = CoreEnvironmentSettings.AltAppID;
-            altId = STEAM_APP_ID_FT;
-            appName = $"Override AppId={appId.ToString()}";
-            altName = "FFXIV Free Trial";
+            apps.Add(CoreEnvironmentSettings.SteamAppId, "XLM");
         }
-        else if (Config.IsFt == true)
+        if (!ignoredIds.Contains(CoreEnvironmentSettings.AltAppID))
         {
-            appId = STEAM_APP_ID_FT;
-            altId = STEAM_APP_ID;
-            appName = "FFXIV Free Trial";
-            altName = "FFXIV Retail";
+            apps.Add(CoreEnvironmentSettings.AltAppID, "XL_APPID");
+        }
+        if (Config.IsFt == true)
+        {
+            apps.Add(STEAM_APP_ID_FT, "FFXIV Free Trial");
+            apps.Add(STEAM_APP_ID, "FFXIV Retail");
         }
         else
         {
-            appId = STEAM_APP_ID;
-            altId = STEAM_APP_ID_FT;
-            appName = "FFXIV Retail";
-            altName = "FFXIV Free Trial";
+            apps.Add(STEAM_APP_ID, "FFXIV Retail");
+            apps.Add(STEAM_APP_ID_FT, "FFXIV Free Trial");
         }
         try
         {
@@ -239,14 +235,18 @@ sealed class Program
             }
             if (Config.IsIgnoringSteam != true || CoreEnvironmentSettings.IsSteamCompatTool)
             {
-                try
+                foreach (var app in apps)
                 {
-                    Steam.Initialize(appId);
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(ex, $"Couldn't init Steam with AppId={appId} ({appName}), trying AppId={altId} ({altName})");
-                    Steam.Initialize(altId);
+                    try
+                    {
+                        Steam.Initialize(app.Key);
+                        Log.Information($"Successfully initialized Steam entry {app.Key} - {app.Value}");
+                        break;
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, $"Failed to initialize Steam Steam entry {app.Key} - {app.Value}");
+                    }
                 }
             }
         }


### PR DESCRIPTION
* Don't hide the window/show deck prompt until ffxiv actually starts launching. This prevents several seconds of the launcher disappearing and nothing happening.
* Don't show the deck prompt in XLM mode (no manual swap is needed).
* Improve steam initialization by using SteamAppId, which is provided by whatever entry you use XLM on in the Steam Library. This allows for use on non-ffxiv entries for Steam regions without FFXIV.