### PR TITLE
chore: bump version to v1.1.1.0

### DIFF
--- a/src/XIVLauncher.Core/XIVLauncher.Core.csproj
+++ b/src/XIVLauncher.Core/XIVLauncher.Core.csproj
@@ -9,7 +9,7 @@
     <LangVersion>latest</LangVersion>
     <ApplicationIcon>Resources\dalamud_icon.ico</ApplicationIcon>
 
-    <Version>1.1.0.0</Version>
+    <Version>1.1.1.0</Version>
     <FileVersion>$(Version)</FileVersion>
     <AssemblyVersion>$(Version)</AssemblyVersion>
 


### PR DESCRIPTION
Preparation for the next release

I'm aware we wanted to try and include more but in the interest of fixing some existing issues with the new compatibility tool method, including ex5 troubleshoot data and fixing the "unknown error" subscription problem I wanted to make a release before doing anything major