### PR TITLE
fix: aria2 will pause and close on exit

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -1005,9 +1005,9 @@ public class MainPage : Page
         }
 
         using var installer = new PatchInstaller(App.Settings.KeepPatches ?? false);
-        var patcher = new PatchManager(App.Settings.PatchAcquisitionMethod ?? AcquisitionMethod.Aria, App.Settings.PatchSpeedLimit, repository, pendingPatches, App.Settings.GamePath,
+        Program.Patcher = new PatchManager(App.Settings.PatchAcquisitionMethod ?? AcquisitionMethod.Aria, App.Settings.PatchSpeedLimit, repository, pendingPatches, App.Settings.GamePath,
             App.Settings.PatchPath, installer, App.Launcher, sid);
-        patcher.OnFail += PatcherOnFail;
+        Program.Patcher.OnFail += PatcherOnFail;
         installer.OnFail += this.InstallerOnFail;
 
         /*
@@ -1039,18 +1039,18 @@ public class MainPage : Page
                 {
                     Thread.Sleep(30);
 
-                    App.LoadingPage.Line2 = string.Format("Working on {0}/{1}", patcher.CurrentInstallIndex, patcher.Downloads.Count);
-                    App.LoadingPage.Line3 = string.Format("{0} left to download at {1}/s", ApiHelpers.BytesToString(patcher.AllDownloadsLength < 0 ? 0 : patcher.AllDownloadsLength),
-                        ApiHelpers.BytesToString(patcher.Speeds.Sum()));
+                    App.LoadingPage.Line2 = string.Format("Working on {0}/{1}", Program.Patcher.CurrentInstallIndex, Program.Patcher.Downloads.Count);
+                    App.LoadingPage.Line3 = string.Format("{0} left to download at {1}/s", ApiHelpers.BytesToString(Program.Patcher.AllDownloadsLength < 0 ? 0 : Program.Patcher.AllDownloadsLength),
+                        ApiHelpers.BytesToString(Program.Patcher.Speeds.Sum()));
 
-                    App.LoadingPage.Progress = patcher.CurrentInstallIndex / (float)patcher.Downloads.Count;
+                    App.LoadingPage.Progress = Program.Patcher.CurrentInstallIndex / (float)Program.Patcher.Downloads.Count;
                 }
             }
 
             try
             {
                 var aria2LogFile = new FileInfo(Path.Combine(App.Storage.GetFolder("logs").FullName, "launcher.log"));
-                await patcher.PatchAsync(aria2LogFile, false).ConfigureAwait(false);
+                await Program.Patcher.PatchAsync(aria2LogFile, false).ConfigureAwait(false);
             }
             finally
             {

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -14,6 +14,7 @@ using Veldrid.StartupUtilities;
 
 using XIVLauncher.Common;
 using XIVLauncher.Common.Dalamud;
+using XIVLauncher.Common.Game.Patch;
 using XIVLauncher.Common.Game.Patch.Acquisition;
 using XIVLauncher.Common.PlatformAbstractions;
 using XIVLauncher.Common.Support;
@@ -50,6 +51,7 @@ sealed class Program
     {
         Timeout = TimeSpan.FromSeconds(5)
     };
+    public static PatchManager Patcher { get; set; } = null!;
 
     private static readonly Vector3 ClearColor = new(0.1f, 0.1f, 0.1f);
 
@@ -357,12 +359,23 @@ sealed class Program
             gd.SwapBuffers(gd.MainSwapchain);
         }
 
-        HttpClient.Dispose();
         // Clean up Veldrid resources
         gd.WaitForIdle();
         bindings.Dispose();
         cl.Dispose();
         gd.Dispose();
+
+        HttpClient.Dispose();
+
+        if (Patcher is not null)
+        {
+            Patcher.CancelAllDownloads();
+            Task.Run(async() =>
+            {
+                await PatchManager.UnInitializeAcquisition().ConfigureAwait(false);
+                Environment.Exit(0);
+            });
+        }
     }
 
     public static void CreateCompatToolsInstance()


### PR DESCRIPTION
Currently, when you close XLCore during the game download process, aria2c will continue downloading in the background. It will also sometimes stay resident when the download is completed. This PR makes sure to pause all current downloads and then force aria2 to close.
