### PR TITLE
build: set right path to xlcommon unix in solution

### DIFF
--- a/src/XIVLauncher.Core.sln
+++ b/src/XIVLauncher.Core.sln
@@ -16,7 +16,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XIVLauncher.Common.Windows"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XIVLauncher.Core", "XIVLauncher.Core\XIVLauncher.Core.csproj", "{05A1B3C0-0795-4045-AE37-474D4A73B1EE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XIVLauncher.Common.Unix", "..\lib\FFXIVQuickLauncher\src\XIVLauncher.Common.Unix\XIVLauncher.Common.Unix.csproj", "{08CE4E78-7C47-43D6-98CB-68655DEAF66A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XIVLauncher.Common.Unix", "XIVLauncher.Common.Unix\XIVLauncher.Common.Unix.csproj", "{08CE4E78-7C47-43D6-98CB-68655DEAF66A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XIVLauncher.VersionGenerator", "XIVLauncher.VersionGenerator\XIVLauncher.VersionGenerator.csproj", "{1F476606-D4C4-4808-8A41-FC22326B7D30}"
 EndProject


### PR DESCRIPTION
Can't properly use intellisense without this.