### PR TITLE
Implement XL_PLATFORM for Unix

### DIFF
--- a/src/XIVLauncher.Common.Unix/UnixGameRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixGameRunner.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+
 using XIVLauncher.Common.Dalamud;
 using XIVLauncher.Common.PlatformAbstractions;
 using XIVLauncher.Common.Unix.Compatibility;
@@ -24,6 +25,7 @@ public class UnixGameRunner : IGameRunner
     {
         if (dalamudOk)
         {
+            environment.Add("XL_PLATFORM", "Linux");
             return this.dalamudLauncher.Run(new FileInfo(path), arguments, environment);
         }
         else

--- a/src/XIVLauncher.Common.Unix/UnixGameRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixGameRunner.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 
 using XIVLauncher.Common.Dalamud;
 using XIVLauncher.Common.PlatformAbstractions;
@@ -25,7 +26,14 @@ public class UnixGameRunner : IGameRunner
     {
         if (dalamudOk)
         {
-            environment.Add("XL_PLATFORM", "Linux");
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                environment.Add("XL_PLATFORM", "Linux");
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                environment.Add("XL_PLATFORM", "MacOS");
+            }
             return this.dalamudLauncher.Run(new FileInfo(path), arguments, environment);
         }
         else

--- a/src/XIVLauncher.Core.sln
+++ b/src/XIVLauncher.Core.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29215.179

--- a/src/XIVLauncher.Core.sln
+++ b/src/XIVLauncher.Core.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29215.179
@@ -16,7 +16,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XIVLauncher.Common.Windows"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XIVLauncher.Core", "XIVLauncher.Core\XIVLauncher.Core.csproj", "{05A1B3C0-0795-4045-AE37-474D4A73B1EE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XIVLauncher.Common.Unix", "XIVLauncher.Common.Unix\XIVLauncher.Common.Unix.csproj", "{08CE4E78-7C47-43D6-98CB-68655DEAF66A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XIVLauncher.Common.Unix", "..\lib\FFXIVQuickLauncher\src\XIVLauncher.Common.Unix\XIVLauncher.Common.Unix.csproj", "{08CE4E78-7C47-43D6-98CB-68655DEAF66A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XIVLauncher.VersionGenerator", "XIVLauncher.VersionGenerator\XIVLauncher.VersionGenerator.csproj", "{1F476606-D4C4-4808-8A41-FC22326B7D30}"
 EndProject


### PR DESCRIPTION
Requested at https://github.com/goatcorp/XIVLauncher.Core/issues/77 for Dalamud here https://github.com/goatcorp/Dalamud/blob/f16a3367c0fad56b4ce760439823122fc6845580/Dalamud/Utility/Util.cs#L527-L534

XL_PLATFORM was also implemented via a seperate PR at https://github.com/goatcorp/FFXIVQuickLauncher/pull/1648 mainly for Windows, but also for XoM (I think it pulls from there for some stuff). 

This just duplicates the work here for the Unix side. The windows stuff will need a submodule update if its ever merged.