### PR TITLE
Do not ask for OTP if cache is valid

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -184,7 +184,7 @@ public class MainPage : Page
 
         var otp = string.Empty;
 
-        if (isOtp)
+        if (isOtp && !App.UniqueIdCache.HasValidCache(username))
         {
             App.AskForOtp();
             otp = App.WaitForOtp();


### PR DESCRIPTION
I saw this issue a year ago when it kept asking us for a otp despite the cached uid being valid, but it took me until now to realise why this was the case