### PR TITLE
Add advanced login option to start without plugins

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/LoginAction.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/LoginAction.cs
@@ -4,6 +4,7 @@ public enum LoginAction
 {
     Game,
     GameNoDalamud,
+    GameNoPlugins,
     GameNoThirdparty,
     GameNoLaunch,
     Repair,

--- a/src/XIVLauncher.Core/Components/MainPage/LoginFrame.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/LoginFrame.cs
@@ -119,6 +119,13 @@ public class LoginFrame : Component
 
                 ImGui.Separator();
 
+                if (ImGui.MenuItem("Launch without any plugins"))
+                {
+                    this.OnLogin?.Invoke(LoginAction.GameNoPlugins);
+                }
+
+                ImGui.Separator();
+
                 if (ImGui.MenuItem("Launch without custom repo plugins"))
                 {
                     this.OnLogin?.Invoke(LoginAction.GameNoThirdparty);

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -369,7 +369,7 @@ public class MainPage : Page
 
             try
             {
-                using var process = await StartGameAndAddon(loginResult, isSteam, action == LoginAction.GameNoDalamud, action == LoginAction.GameNoThirdparty).ConfigureAwait(false);
+                using var process = await StartGameAndAddon(loginResult, isSteam, action == LoginAction.GameNoDalamud, action == LoginAction.GameNoPlugins, action == LoginAction.GameNoThirdparty).ConfigureAwait(false);
 
                 if (process is null)
                     throw new InvalidOperationException("Could not obtain Process Handle");
@@ -592,7 +592,7 @@ public class MainPage : Page
         }
     }
 
-    public async Task<Process> StartGameAndAddon(Launcher.LoginResult loginResult, bool isSteam, bool forceNoDalamud, bool noThird)
+    public async Task<Process> StartGameAndAddon(Launcher.LoginResult loginResult, bool isSteam, bool forceNoDalamud, bool noPlugins , bool noThird)
     {
         var dalamudOk = false;
 
@@ -620,7 +620,7 @@ public class MainPage : Page
         var dalamudLauncher = new DalamudLauncher(dalamudRunner, Program.DalamudUpdater,
             App.Settings.DalamudLoadMethod.GetValueOrDefault(DalamudLoadMethod.DllInject), App.Settings.GamePath,
             App.Storage.Root, App.Storage.GetFolder("logs"), App.Settings.ClientLanguage ?? ClientLanguage.English,
-            App.Settings.DalamudLoadDelay, false, false, noThird, Troubleshooting.GetTroubleshootingJson());
+            App.Settings.DalamudLoadDelay, false, noPlugins, noThird, Troubleshooting.GetTroubleshootingJson());
 
         try
         {


### PR DESCRIPTION
Feature parity with XIVLauncher WPF.

Adds an option to run the game with Dalamud, but without any plugins.

I only briefly tested this on windows, and xlcore had some other display issues in terms of some imgui tabs, but Dalamud did launch/inject as intended correctly.

This would be best tested on someone's Linux machine to ensure all advanced options continue to work as intended.
