### PR TITLE
Add Reset UID Cache button

### DIFF
--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
@@ -1,3 +1,4 @@
+using ImGuiNET;
 using XIVLauncher.Common;
 
 namespace XIVLauncher.Core.Components.SettingsPage.Tabs;
@@ -45,5 +46,10 @@ public class SettingsTabGame : SettingsTab
     public override void Draw()
     {
         base.Draw();
+
+        if (ImGui.Button("Reset UID Cache"))
+        {
+            Program.ResetUIDCache();
+        }
     }
 }

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
@@ -38,7 +38,7 @@ public class SettingsTabGame : SettingsTab
         {
             CheckVisibility = () => !CoreEnvironmentSettings.IsSteamCompatTool,
         },
-        new SettingsEntry<bool>("Use Experimental UID Cache", "Tries to save your login token for the next start. Can result in launching with expired sessions.\nDisable if receiving FFXIV error 1012 or 500X.", () => Program.Config.IsUidCacheEnabled ?? false, x => Program.Config.IsUidCacheEnabled = x),
+        new SettingsEntry<bool>("Use Experimental UID Cache", "Tries to save your login token for the next start. Can result in launching with expired sessions.", () => Program.Config.IsUidCacheEnabled ?? false, x => Program.Config.IsUidCacheEnabled = x),
     };
 
     public override string Title => "Game";
@@ -47,9 +47,13 @@ public class SettingsTabGame : SettingsTab
     {
         base.Draw();
 
-        if (ImGui.Button("Reset UID Cache"))
+        if (Program.Config.IsUidCacheEnabled == true)
         {
-            Program.ResetUIDCache();
+            ImGui.Text("Reset the UID cache; use if you are getting FFXIV error 1012 or 500X.");
+            if (ImGui.Button("Reset UID Cache"))
+            {
+                Program.ResetUIDCache();
+            }
         }
     }
 }

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -495,4 +495,6 @@ sealed class Program
         ClearTools(tsbutton);
         ClearLogs(true);
     }
+
+    public static void ResetUIDCache(bool tsbutton = false) => launcherApp.UniqueIdCache.Reset();
 }


### PR DESCRIPTION
Noticed this after using 1689352db89a3644c4588fb2e765b32ce6fbda05 and updating to 7.15.
As the UID cache can not be manually reset, a user would have to disable the feature entirely or manually remove the entries from the saved data in order to force saving an updated token.