### PR TITLE
Add fix for libicuuc error: "An internal Dalamud error has occured"

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -711,6 +711,12 @@ public class MainPage : Page
             System.Environment.SetEnvironmentVariable("XMODIFIERS", "@im=null");
         }
 
+        // Hack: Fix libicuuc dalamud crashes
+        if (App.Settings.FixError127 == true)
+        {
+            System.Environment.SetEnvironmentVariable("DOTNET_SYSTEM_GLOBALIZATION_USENLS", "true");
+        }
+
         // Deal with "Additional Arguments". VAR=value %command% -args
         var launchOptions = (App.Settings.AdditionalArgs ?? string.Empty).Split("%command%", 2);
         var launchEnv = "";

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
@@ -11,7 +11,7 @@ public class SettingsTabTroubleshooting : SettingsTab
     {
         new SettingsEntry<bool>("Hack: Disable gameoverlayrenderer.so", "May fix black screen on launch (Steam Deck) and some stuttering issues after 40+ minutes.", () => Program.Config.FixLDP ?? false, x => Program.Config.FixLDP = x),
         new SettingsEntry<bool>("Hack: XMODIFIERS=\"@im=null\"", "Fixes some mouse-related issues, some stuttering issues", () => Program.Config.FixIM ?? false, x => Program.Config.FixIM = x),
-        new SettingsEntry<bool>("Hack: Fix libicuuc dalamud crashes", "Fixes some dalamud crashes that look like this when runing xivlauncher from terminal:\n\"Cannot get symbol u_charsToUChars from libicuuc Error: 127\"", () => Program.Config.FixError127 ?? false, x => Program.Config.FixError127 = x),
+        new SettingsEntry<bool>("Hack: Fix libicuuc Dalamud error", "Fixes a specific \"an internal Dalamud error has occurred.\" In the terminal you will see this text:\n\"Cannot get symbol u_charsToUChars from libicuuc Error: 127\"", () => Program.Config.FixError127 ?? false, x => Program.Config.FixError127 = x),
         new SettingsEntry<bool>($"Hack: Force locale to {(!string.IsNullOrEmpty(Program.CType) ? Program.CType : "C.UTF-8 (exact value depends on distro)")}",
                                 !string.IsNullOrEmpty(Program.CType) ? $"Sets LC_ALL and LC_CTYPE to \"{Program.CType}\". This can fix some issues with non-Latin unicode characters in file paths if LANG is not a UTF-8 type" : "Hack Disabled. Could not find a UTF-8 C locale. You may have to set LC_ALL manually if LANG is not a UTF-8 type.",
                                 () => Program.Config.FixLocale ?? false, b => Program.Config.FixLocale = b)

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabTroubleshooting.cs
@@ -11,6 +11,7 @@ public class SettingsTabTroubleshooting : SettingsTab
     {
         new SettingsEntry<bool>("Hack: Disable gameoverlayrenderer.so", "May fix black screen on launch (Steam Deck) and some stuttering issues after 40+ minutes.", () => Program.Config.FixLDP ?? false, x => Program.Config.FixLDP = x),
         new SettingsEntry<bool>("Hack: XMODIFIERS=\"@im=null\"", "Fixes some mouse-related issues, some stuttering issues", () => Program.Config.FixIM ?? false, x => Program.Config.FixIM = x),
+        new SettingsEntry<bool>("Hack: Fix libicuuc dalamud crashes", "Fixes some dalamud crashes that look like this when runing xivlauncher from terminal:\n\"Cannot get symbol u_charsToUChars from libicuuc Error: 127\"", () => Program.Config.FixError127 ?? false, x => Program.Config.FixError127 = x),
         new SettingsEntry<bool>($"Hack: Force locale to {(!string.IsNullOrEmpty(Program.CType) ? Program.CType : "C.UTF-8 (exact value depends on distro)")}",
                                 !string.IsNullOrEmpty(Program.CType) ? $"Sets LC_ALL and LC_CTYPE to \"{Program.CType}\". This can fix some issues with non-Latin unicode characters in file paths if LANG is not a UTF-8 type" : "Hack Disabled. Could not find a UTF-8 C locale. You may have to set LC_ALL manually if LANG is not a UTF-8 type.",
                                 () => Program.Config.FixLocale ?? false, b => Program.Config.FixLocale = b)

--- a/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
+++ b/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
@@ -82,6 +82,8 @@ public interface ILauncherConfig
 
     public bool? FixIM { get; set; }
 
+    public bool? FixError127 { get; set; }
+
     public bool? SetWin7 { get; set; }
 
     #endregion

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -139,6 +139,7 @@ sealed class Program
         Config.FixLDP ??= false;
         Config.FixIM ??= false;
         Config.FixLocale ??= false;
+        Config.FixError127 ??= false;
     }
 
     public const uint STEAM_APP_ID = 39210;


### PR DESCRIPTION
Fix for a particular cause of "An internal Dalamud error has occured"

Adds a hack to the troubleshooting tab that fixes the libicuuc error. This error occurs when someone uses recent bleeding edge proton-based wine, wine from Proton-experimental, or from Proton-GE. It does this by setting an evironment variable: `DOTNET_SYSTEM_GLOBALIZATION_USENLS=true`

(The ValveBE builds I provide are not affected; the problematic icu code is patched out.)


![add-libicuuc-hack](https://github.com/user-attachments/assets/3734a418-3088-4eab-91c0-876d995056d6)
