### PR TITLE
fix: Show otp prompt when uid cache disabled

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -184,7 +184,10 @@ public class MainPage : Page
 
         var otp = string.Empty;
         
-        if (isOtp && (!App.UniqueIdCache.HasValidCache(username) || App.Settings.IsUidCacheEnabled == false))
+        if (isOtp && App.UniqueIdCache.HasValidCache(username) && App.Settings.IsUidCacheEnabled == false)
+            Program.ResetUIDCache();
+
+        if (isOtp && !App.UniqueIdCache.HasValidCache(username))
         {
             App.AskForOtp();
             otp = App.WaitForOtp();

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -183,8 +183,8 @@ public class MainPage : Page
             return false;
 
         var otp = string.Empty;
-
-        if (isOtp && !App.UniqueIdCache.HasValidCache(username))
+        
+        if (isOtp && (!App.UniqueIdCache.HasValidCache(username) || App.Settings.IsUidCacheEnabled == false))
         {
             App.AskForOtp();
             otp = App.WaitForOtp();


### PR DESCRIPTION
We need to assume that if the user disables the UID cache, they will expect to see the OTP prompt. However, that is not currently the case (when built from current git). Currently, if the UID cache is enabled, and a valid UID is saved, then switching off UID cache will not show OTP prompt, instead using the saved UID. This will cause issues when the UID cache expires, as the button to clear the cache only shows if the UID cache is enabled.

This commit forces the OTP prompt to be shown if uid cache is disabled.