### PR TITLE
Update DXVK to async v2.6

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
@@ -8,8 +8,8 @@ namespace XIVLauncher.Common.Unix.Compatibility;
 
 public static class Dxvk
 {
-    private const string DXVK_DOWNLOAD = "https://github.com/Sporif/dxvk-async/releases/download/1.10.1/dxvk-async-1.10.1.tar.gz";
-    private const string DXVK_NAME = "dxvk-async-1.10.1";
+    private const string DXVK_DOWNLOAD = "https://gitlab.com/Ph42oN/dxvk-gplasync/-/raw/447db06ecff8a64f900b12741dbd8d1c8d8eae22/releases/dxvk-gplasync-v2.6-1.tar.gz";
+    private const string DXVK_NAME = "dxvk-gplasync-v2.6-1";
 
     public static async Task InstallDxvk(DirectoryInfo prefix, DirectoryInfo installDirectory)
     {


### PR DESCRIPTION
Requires a driver that supports Vulkan 1.3. The game's minimum system requirements lists cards that support Vulkan 1.3, so this should be an acceptable change.

More information on driver support here https://github.com/doitsujin/dxvk/wiki/Driver-support/394593313562bb72bcff5c297c1b2a3e6a2c9846