### PR TITLE
Simple compat rework

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -69,6 +69,8 @@ public class CompatibilityTools
 
     public async Task EnsureTool(DirectoryInfo tempPath)
     {
+        Console.WriteLine(WineBinPath);
+        Console.WriteLine(Wine64Path);
         if (!File.Exists(Wine64Path))
         {
             Log.Information("Compatibility tool does not exist, downloading");
@@ -76,13 +78,17 @@ public class CompatibilityTools
         }
 
         EnsurePrefix();
+        Console.WriteLine("Checking Dxvk");
+        Console.WriteLine($"Dxvk is {(DxvkVersion == DxvkVersion.Disabled ? "disabled" : "enabled")}");
         await Dxvk.InstallDxvk(Settings.Prefix, dxvkDirectory, DxvkVersion).ConfigureAwait(false);
+        Console.WriteLine("Dxvk Installed");
 
         IsToolReady = true;
     }
 
     private async Task DownloadTool(DirectoryInfo tempPath)
     {
+        Console.WriteLine("Downloading wine");
         using var client = new HttpClient();
         var tempFilePath = Path.Combine(tempPath.FullName, $"{Guid.NewGuid()}");
 
@@ -155,7 +161,7 @@ public class CompatibilityTools
 
         var wineEnviromentVariables = new Dictionary<string, string>();
         wineEnviromentVariables.Add("WINEPREFIX", Settings.Prefix.FullName);
-        wineEnviromentVariables.Add("WINEDLLOVERRIDES", $"{WINEDLLOVERRIDES}{(ogl ? "b" : "n")}");
+        wineEnviromentVariables.Add("WINEDLLOVERRIDES", $"{WINEDLLOVERRIDES}{(ogl ? "b" : "n,b")}");
 
         if (!string.IsNullOrEmpty(Settings.DebugVars))
         {

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -69,8 +69,6 @@ public class CompatibilityTools
 
     public async Task EnsureTool(DirectoryInfo tempPath)
     {
-        Console.WriteLine(WineBinPath);
-        Console.WriteLine(Wine64Path);
         if (!File.Exists(Wine64Path))
         {
             Log.Information("Compatibility tool does not exist, downloading");
@@ -78,17 +76,13 @@ public class CompatibilityTools
         }
 
         EnsurePrefix();
-        Console.WriteLine("Checking Dxvk");
-        Console.WriteLine($"Dxvk is {(DxvkVersion == DxvkVersion.Disabled ? "disabled" : "enabled")}");
         await Dxvk.InstallDxvk(Settings.Prefix, dxvkDirectory, DxvkVersion).ConfigureAwait(false);
-        Console.WriteLine("Dxvk Installed");
 
         IsToolReady = true;
     }
 
     private async Task DownloadTool(DirectoryInfo tempPath)
     {
-        Console.WriteLine("Downloading wine");
         using var client = new HttpClient();
         var tempFilePath = Path.Combine(tempPath.FullName, $"{Guid.NewGuid()}");
 

--- a/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Serilog;
@@ -8,17 +9,40 @@ namespace XIVLauncher.Common.Unix.Compatibility;
 
 public static class Dxvk
 {
-    private const string DXVK_DOWNLOAD = "https://gitlab.com/Ph42oN/dxvk-gplasync/-/raw/447db06ecff8a64f900b12741dbd8d1c8d8eae22/releases/dxvk-gplasync-v2.6-1.tar.gz";
-    private const string DXVK_NAME = "dxvk-gplasync-v2.6-1";
+    private const string DXVK_CURRENT_NAME = "dxvk-gplasync-v2.6-1";
+    private const string DXVK_CURRENT_URL = "https://gitlab.com/Ph42oN/dxvk-gplasync/-/raw/main/releases/dxvk-gplasync-v2.6-1.tar.gz";
+    private const string DXVK_LEGACY_NAME = "dxvk-async-1.10.3";
+    private const string DXVK_LEGACY_URL = "https://github.com/Sporif/dxvk-async/releases/download/1.10.3/dxvk-async-1.10.3.tar.gz";
 
-    public static async Task InstallDxvk(DirectoryInfo prefix, DirectoryInfo installDirectory)
+
+    public static async Task InstallDxvk(DirectoryInfo prefix, DirectoryInfo installDirectory, DxvkVersion version)
     {
-        var dxvkPath = Path.Combine(installDirectory.FullName, DXVK_NAME, "x64");
+        string name;
+        string url;
+        switch (version)
+        {
+            case DxvkVersion.Current:
+                name = DXVK_CURRENT_NAME;
+                url = DXVK_CURRENT_URL;
+                break;
+            
+            case DxvkVersion.Legacy:
+                name = DXVK_LEGACY_NAME;
+                url = DXVK_LEGACY_URL;
+                break;
+
+            case DxvkVersion.Disabled:
+                return;
+
+            default:
+                throw new ArgumentOutOfRangeException("Invalid Dxvk.DxvkVersion. Value does not exist.");
+        }
+        var dxvkPath = Path.Combine(installDirectory.FullName, name, "x64");
 
         if (!Directory.Exists(dxvkPath))
         {
             Log.Information("DXVK does not exist, downloading");
-            await DownloadDxvk(installDirectory).ConfigureAwait(false);
+            await DownloadDxvk(installDirectory, url).ConfigureAwait(false);
         }
 
         var system32 = Path.Combine(prefix.FullName, "drive_c", "windows", "system32");
@@ -30,26 +54,38 @@ public static class Dxvk
         }
     }
 
-    private static async Task DownloadDxvk(DirectoryInfo installDirectory)
+    private static async Task DownloadDxvk(DirectoryInfo installDirectory, string url)
     {
         using var client = new HttpClient();
         var tempPath = PlatformHelpers.GetTempFileName();
 
-        File.WriteAllBytes(tempPath, await client.GetByteArrayAsync(DXVK_DOWNLOAD));
+        File.WriteAllBytes(tempPath, await client.GetByteArrayAsync(url));
         PlatformHelpers.Untar(tempPath, installDirectory.FullName);
 
         File.Delete(tempPath);
     }
+}
 
-    public enum DxvkHudType
-    {
-        [SettingsDescription("None", "Show nothing")]
-        None,
+public enum DxvkHudType
+{
+    [SettingsDescription("None", "Show nothing")]
+    None,
 
-        [SettingsDescription("FPS", "Only show FPS")]
-        Fps,
+    [SettingsDescription("FPS", "Only show FPS")]
+    Fps,
 
-        [SettingsDescription("Full", "Show everything")]
-        Full,
-    }
+    [SettingsDescription("Full", "Show everything")]
+    Full,
+}
+
+public enum DxvkVersion
+{
+    [SettingsDescription("GPLAsync 2.6", "Dxvk 2.6 with GPLAsync patches. For most graphics cards.")]
+    Current,
+
+    [SettingsDescription("Async 1.10.3", "Dxvk 1.10.3 with Async patches. For older graphics cards.")]
+    Legacy,
+
+    [SettingsDescription("Disabled", "Use OpenGL/WineD3D instead. Slow, and might not work with Dalamud.")]
+    Disabled,
 }

--- a/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
@@ -19,7 +19,6 @@ public static class Dxvk
     {
         string name;
         string url;
-        Console.WriteLine("Installing DXVK");
         switch (version)
         {
             case DxvkVersion.Current:
@@ -38,9 +37,7 @@ public static class Dxvk
             default:
                 throw new ArgumentOutOfRangeException("Invalid Dxvk.DxvkVersion. Value does not exist.");
         }
-        Console.WriteLine($"name = {name}, url = {url}");
         var dxvkPath = Path.Combine(installDirectory.FullName, name, "x64");
-        Console.WriteLine(dxvkPath);
 
         if (!Directory.Exists(dxvkPath))
         {
@@ -59,7 +56,6 @@ public static class Dxvk
 
     private static async Task DownloadDxvk(DirectoryInfo installDirectory, string url)
     {
-        Console.WriteLine($"Downloading Dxvk from {url}");
         using var client = new HttpClient();
         var tempPath = PlatformHelpers.GetTempFileName();
 

--- a/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
@@ -80,10 +80,10 @@ public enum DxvkHudType
 
 public enum DxvkVersion
 {
-    [SettingsDescription("GPLAsync 2.6", "Dxvk 2.6 with GPLAsync patches. For most graphics cards.")]
+    [SettingsDescription("Current", "Dxvk 2.6 with GPLAsync patches. For most graphics cards.")]
     Current,
 
-    [SettingsDescription("Async 1.10.3", "Dxvk 1.10.3 with Async patches. For older graphics cards.")]
+    [SettingsDescription("Legacy", "Dxvk 1.10.3 with Async patches. For older graphics cards.")]
     Legacy,
 
     [SettingsDescription("Disabled", "Use OpenGL/WineD3D instead. Slow, and might not work with Dalamud.")]

--- a/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
@@ -19,6 +19,7 @@ public static class Dxvk
     {
         string name;
         string url;
+        Console.WriteLine("Installing DXVK");
         switch (version)
         {
             case DxvkVersion.Current:
@@ -37,7 +38,9 @@ public static class Dxvk
             default:
                 throw new ArgumentOutOfRangeException("Invalid Dxvk.DxvkVersion. Value does not exist.");
         }
+        Console.WriteLine($"name = {name}, url = {url}");
         var dxvkPath = Path.Combine(installDirectory.FullName, name, "x64");
+        Console.WriteLine(dxvkPath);
 
         if (!Directory.Exists(dxvkPath))
         {
@@ -56,6 +59,7 @@ public static class Dxvk
 
     private static async Task DownloadDxvk(DirectoryInfo installDirectory, string url)
     {
+        Console.WriteLine($"Downloading Dxvk from {url}");
         using var client = new HttpClient();
         var tempPath = PlatformHelpers.GetTempFileName();
 

--- a/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
@@ -31,10 +31,10 @@ public class WineSettings
 #else
     private const string DISTRO = "ubuntu";
 #endif
-    private const string CURRENT_RELEASE = "8.5.r4.g4211bac7";
-    private const string LEGACY_RELEASE = "8.5.r4.g4211bac7";
-    private string CURRENT_RELEASE_URL => $"https://github.com/goatcorp/wine-xiv-git/releases/download/{CURRENT_RELEASE}/wine-xiv-staging-fsync-git-{DISTRO}-{CURRENT_RELEASE}.tar.xz";
-    private string LEGACY_RELEASE_URL => $"https://github.com/goatcorp/wine-xiv-git/releases/download/{LEGACY_RELEASE}/wine-xiv-staging-fsync-git-{DISTRO}-{LEGACY_RELEASE}.tar.xz";
+    private const string CURRENT_RELEASE = "wine-xiv-staging-fsync-git-10.5.r0.g835c92a2";
+    private const string LEGACY_RELEASE = "wine-xiv-staging-fsync-git-8.5.r4.g4211bac7";
+    private string CURRENT_RELEASE_URL => $"https://github.com/rankynbass/unofficial-wine-xiv-git/releases/download/10.5.r0.g835c92a2/wine-xiv-staging-fsync-git-{DISTRO}-10.5.r0.g835c92a2.tar.xz";
+    private string LEGACY_RELEASE_URL => $"https://github.com/goatcorp/wine-xiv-git/releases/download/8.5.r4.g4211bac7/wine-xiv-staging-fsync-git-{DISTRO}-8.5.r4.g4211bac7.tar.xz";
 
     public string ReleaseName { get; private set; }
     public string ReleaseUrl { get; private set; }

--- a/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System;
 
 namespace XIVLauncher.Common.Unix.Compatibility;
 
@@ -11,9 +12,33 @@ public enum WineStartupType
     Custom,
 }
 
+public enum WineManagedVersion
+{
+    [SettingsDescription("Current", "Based on Wine 10.5, with patches for Dalamud and XIVLauncher")]
+    Current,
+    
+    [SettingsDescription("Legacy", "Based on Wine 8.5. Useful for certain third-party plugins")]
+    Legacy,
+}
+
 public class WineSettings
 {
     public WineStartupType StartupType { get; private set; }
+#if WINE_XIV_ARCH_LINUX
+    private const string DISTRO = "arch";
+#elif WINE_XIV_FEDORA_LINUX
+    private const string DISTRO = "fedora";
+#else
+    private const string DISTRO = "ubuntu";
+#endif
+    private const string CURRENT_RELEASE = "8.5.r4.g4211bac7";
+    private const string LEGACY_RELEASE = "8.5.r4.g4211bac7";
+    private string CURRENT_RELEASE_URL => $"https://github.com/goatcorp/wine-xiv-git/releases/download/{CURRENT_RELEASE}/wine-xiv-staging-fsync-git-{DISTRO}-{CURRENT_RELEASE}.tar.xz";
+    private string LEGACY_RELEASE_URL => $"https://github.com/goatcorp/wine-xiv-git/releases/download/{LEGACY_RELEASE}/wine-xiv-staging-fsync-git-{DISTRO}-{LEGACY_RELEASE}.tar.xz";
+
+    public string ReleaseName { get; private set; }
+    public string ReleaseUrl { get; private set; }
+    
     public string CustomBinPath { get; private set; }
 
     public string EsyncOn { get; private set; }
@@ -24,9 +49,22 @@ public class WineSettings
 
     public DirectoryInfo Prefix { get; private set; }
 
-    public WineSettings(WineStartupType? startupType, string customBinPath, string debugVars, FileInfo logFile, DirectoryInfo prefix, bool? esyncOn, bool? fsyncOn)
+    public WineSettings(WineStartupType? startupType, WineManagedVersion? managedWine, string customBinPath, string debugVars, FileInfo logFile, DirectoryInfo prefix, bool? esyncOn, bool? fsyncOn)
     {
         this.StartupType = startupType ?? WineStartupType.Custom;
+        this.ReleaseName = managedWine switch
+        {
+            WineManagedVersion.Current => CURRENT_RELEASE,
+            WineManagedVersion.Legacy => LEGACY_RELEASE,
+            _ => throw new ArgumentOutOfRangeException(),
+        };
+        this.ReleaseUrl = managedWine switch
+        {
+            WineManagedVersion.Current => CURRENT_RELEASE_URL,
+            WineManagedVersion.Legacy => LEGACY_RELEASE_URL,
+            _ => throw new ArgumentOutOfRangeException(),
+        };
+
         this.CustomBinPath = customBinPath;
         this.EsyncOn = (esyncOn ?? false) ? "1" : "0";
         this.FsyncOn = (fsyncOn ?? false) ? "1" : "0";

--- a/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
@@ -31,9 +31,12 @@ public class WineSettings
 #else
     private const string DISTRO = "ubuntu";
 #endif
+    // These lines need to be changed to point at an official release
     private const string CURRENT_RELEASE = "wine-xiv-staging-fsync-git-10.5.r0.g835c92a2";
-    private const string LEGACY_RELEASE = "wine-xiv-staging-fsync-git-8.5.r4.g4211bac7";
     private string CURRENT_RELEASE_URL => $"https://github.com/rankynbass/unofficial-wine-xiv-git/releases/download/10.5.r0.g835c92a2/wine-xiv-staging-fsync-git-{DISTRO}-10.5.r0.g835c92a2.tar.xz";
+
+    // These point to the current release, which will hopefully become the legacy release
+    private const string LEGACY_RELEASE = "wine-xiv-staging-fsync-git-8.5.r4.g4211bac7";
     private string LEGACY_RELEASE_URL => $"https://github.com/goatcorp/wine-xiv-git/releases/download/8.5.r4.g4211bac7/wine-xiv-staging-fsync-git-{DISTRO}-8.5.r4.g4211bac7.tar.xz";
 
     public string ReleaseName { get; private set; }

--- a/src/XIVLauncher.Core/Components/SettingsPage/SettingsTab.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/SettingsTab.cs
@@ -17,9 +17,10 @@ public abstract class SettingsTab : Component
         foreach (SettingsEntry settingsEntry in Entries)
         {
             if (settingsEntry.IsVisible)
+            {
                 settingsEntry.Draw();
-
-            ImGui.Dummy(new Vector2(10) * ImGuiHelpers.GlobalScale);
+                ImGui.Dummy(new Vector2(10) * ImGuiHelpers.GlobalScale);
+            }
         }
 
         base.Draw();

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -21,7 +21,7 @@ public class SettingsTabWine : SettingsTab
             startupTypeSetting = new SettingsEntry<WineStartupType>("Wine Version", "Choose how XIVLauncher will start and manage your wine installation.",
                 () => Program.Config.WineStartupType ?? WineStartupType.Managed, x => Program.Config.WineStartupType = x),
 
-            new SettingsEntry<WineManagedVersion>("Wine Release", "Choose which release of Wine-XIV you would like to use.", () => Program.Config.WineManagedVersion ?? WineManagedVersion.Current,
+            new SettingsEntry<WineManagedVersion>("Wine Release", "If you change wine releases, you might have to clear your prefix (Troubleshooting tab)", () => Program.Config.WineManagedVersion ?? WineManagedVersion.Current,
                 x => Program.Config.WineManagedVersion = x )
             {
                 CheckVisibility = () => startupTypeSetting.Value == WineStartupType.Managed

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -12,6 +12,8 @@ public class SettingsTabWine : SettingsTab
 {
     private SettingsEntry<WineStartupType> startupTypeSetting;
 
+    private SettingsEntry<DxvkVersion> dxvkVersionSetting;
+
     public SettingsTabWine()
     {
         Entries = new SettingsEntry[]
@@ -19,11 +21,24 @@ public class SettingsTabWine : SettingsTab
             startupTypeSetting = new SettingsEntry<WineStartupType>("Wine Version", "Choose how XIVLauncher will start and manage your wine installation.",
                 () => Program.Config.WineStartupType ?? WineStartupType.Managed, x => Program.Config.WineStartupType = x),
 
+            new SettingsEntry<WineManagedVersion>("Wine Release", "Choose which release of Wine-XIV you would like to use.", () => Program.Config.WineManagedVersion ?? WineManagedVersion.Current,
+                x => Program.Config.WineManagedVersion = x )
+            {
+                CheckVisibility = () => startupTypeSetting.Value == WineStartupType.Managed
+            },
+
             new SettingsEntry<string>("Wine Binary Path",
                 "Set the path XIVLauncher will use to run applications via wine.\nIt should be an absolute path to a folder containing wine64 and wineserver binaries.",
                 () => Program.Config.WineBinaryPath, s => Program.Config.WineBinaryPath = s)
             {
                 CheckVisibility = () => startupTypeSetting.Value == WineStartupType.Custom
+            },
+
+            dxvkVersionSetting = new SettingsEntry<DxvkVersion>("Dxvk Version", "Choose which Dxvk version to use.", () => Program.Config.DxvkVersion ?? DxvkVersion.Current, x => Program.Config.DxvkVersion = x),
+
+            new SettingsEntry<bool>("Enable DXVK ASYNC", "Enable DXVK ASYNC patch.", () => Program.Config.DxvkAsyncEnabled ?? true, b => Program.Config.DxvkAsyncEnabled = b)
+            {
+                CheckVisibility = () => dxvkVersionSetting.Value != DxvkVersion.Disabled
             },
 
             new SettingsEntry<bool>("Enable Feral's GameMode", "Enable launching with Feral Interactive's GameMode CPU optimizations.", () => Program.Config.GameModeEnabled ?? true, b => Program.Config.GameModeEnabled = b)
@@ -39,7 +54,6 @@ public class SettingsTabWine : SettingsTab
                 }
             },
 
-            new SettingsEntry<bool>("Enable DXVK ASYNC", "Enable DXVK ASYNC patch.", () => Program.Config.DxvkAsyncEnabled ?? true, b => Program.Config.DxvkAsyncEnabled = b),
             new SettingsEntry<bool>("Enable ESync", "Enable eventfd-based synchronization.", () => Program.Config.ESyncEnabled ?? true, b => Program.Config.ESyncEnabled = b),
             new SettingsEntry<bool>("Enable FSync", "Enable fast user mutex (futex2).", () => Program.Config.FSyncEnabled ?? true, b => Program.Config.FSyncEnabled = b)
             {
@@ -55,7 +69,7 @@ public class SettingsTabWine : SettingsTab
 
             new SettingsEntry<bool>("Set Windows version to 7", "Default for Wine 8.1+ is Windows 10, but this causes issues with some Dalamud plugins. Windows 7 is recommended for now.", () => Program.Config.SetWin7 ?? true, b => Program.Config.SetWin7 = b),
 
-            new SettingsEntry<Dxvk.DxvkHudType>("DXVK Overlay", "Configure how much of the DXVK overlay is to be shown.", () => Program.Config.DxvkHudType, type => Program.Config.DxvkHudType = type),
+            new SettingsEntry<DxvkHudType>("DXVK Overlay", "Configure how much of the DXVK overlay is to be shown.", () => Program.Config.DxvkHudType, type => Program.Config.DxvkHudType = type),
             new SettingsEntry<string>("WINEDEBUG Variables", "Configure debug logging for wine. Useful for troubleshooting.", () => Program.Config.WineDebugVars ?? string.Empty, s => Program.Config.WineDebugVars = s)
         };
     }

--- a/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
+++ b/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
@@ -62,9 +62,13 @@ public interface ILauncherConfig
 
     public WineStartupType? WineStartupType { get; set; }
 
+    public WineManagedVersion? WineManagedVersion { get; set; }
+
     public string? WineBinaryPath { get; set; }
 
     public bool? GameModeEnabled { get; set; }
+
+    public DxvkVersion? DxvkVersion { get; set; }
 
     public bool? DxvkAsyncEnabled { get; set; }
 
@@ -72,7 +76,7 @@ public interface ILauncherConfig
 
     public bool? FSyncEnabled { get; set; }
 
-    public Dxvk.DxvkHudType DxvkHudType { get; set; }
+    public DxvkHudType DxvkHudType { get; set; }
 
     public string? WineDebugVars { get; set; }
 

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -460,7 +460,7 @@ sealed class Program
     public static void ClearTools(bool tsbutton = false)
     {
         storage.GetFolder("compatibilitytool").Delete(true);
-        storage.GetFolder("compatibilitytool/beta");
+        storage.GetFolder("compatibilitytool/wine");
         storage.GetFolder("compatibilitytool/dxvk");
         if (tsbutton) CreateCompatToolsInstance();
     }

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -127,12 +127,14 @@ sealed class Program
         Config.GlobalScale ??= 1.0f;
 
         Config.GameModeEnabled ??= false;
+        Config.DxvkVersion ??= DxvkVersion.Current;
         Config.DxvkAsyncEnabled ??= true;
         Config.ESyncEnabled ??= true;
         Config.FSyncEnabled ??= false;
         Config.SetWin7 ??= true;
 
         Config.WineStartupType ??= WineStartupType.Managed;
+        Config.WineManagedVersion ??= WineManagedVersion.Current;
         Config.WineBinaryPath ??= "/usr/bin";
         Config.WineDebugVars ??= "-all";
 
@@ -369,11 +371,11 @@ sealed class Program
     {
         var wineLogFile = new FileInfo(Path.Combine(storage.GetFolder("logs").FullName, "wine.log"));
         var winePrefix = storage.GetFolder("wineprefix");
-        var wineSettings = new WineSettings(Config.WineStartupType, Config.WineBinaryPath, Config.WineDebugVars, wineLogFile, winePrefix, Config.ESyncEnabled, Config.FSyncEnabled);
+        var wineSettings = new WineSettings(Config.WineStartupType, Config.WineManagedVersion, Config.WineBinaryPath, Config.WineDebugVars, wineLogFile, winePrefix, Config.ESyncEnabled, Config.FSyncEnabled);
         var toolsFolder = storage.GetFolder("compatibilitytool");
         Directory.CreateDirectory(Path.Combine(toolsFolder.FullName, "dxvk"));
-        Directory.CreateDirectory(Path.Combine(toolsFolder.FullName, "beta"));
-        CompatibilityTools = new CompatibilityTools(wineSettings, Config.DxvkHudType, Config.GameModeEnabled, Config.DxvkAsyncEnabled, toolsFolder);
+        Directory.CreateDirectory(Path.Combine(toolsFolder.FullName, "wine"));
+        CompatibilityTools = new CompatibilityTools(wineSettings, Config.DxvkVersion, Config.DxvkHudType, Config.GameModeEnabled, Config.DxvkAsyncEnabled, toolsFolder);
     }
 
     public static void ShowWindow()


### PR DESCRIPTION
Here's a very simple, minimalistic compatiblity rework. It only includes current and legacy versions of wine and dxvk, plus the ability to disable dxvk and use wined3d instead. For the moment, I have current wine pointing at a testing version of wine-xiv-git 10.5 hosted on my unofficial-wine-xiv-git repo. This would obviously need to be changed, but I needed it there to demonstrate that it works.

![simple-compat-rework](https://github.com/user-attachments/assets/b5924fa4-bf71-4c79-802c-c6bc0b570dc8)
