### PR TITLE
fix: Spawn Launcher Window on Primary Display

### DIFF
--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -1,6 +1,4 @@
 using System.Numerics;
-using System.Runtime.InteropServices;
-using System.Text;
 
 using CheapLoc;
 

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -1,4 +1,6 @@
 using System.Numerics;
+using System.Runtime.InteropServices;
+using System.Text;
 
 using CheapLoc;
 
@@ -161,7 +163,7 @@ sealed class Program
     /// <returns>A <see cref="DalamudUpdater"/> instance.</returns>
     private static DalamudUpdater CreateDalamudUpdater()
     {
-        FileInfo runnerOverride = null;
+        FileInfo? runnerOverride = null;
         if (Config.DalamudManualInjectPath is not null &&
             Config.DalamudManualInjectionEnabled == true &&
             Config.DalamudManualInjectPath.Exists &&
@@ -201,8 +203,8 @@ sealed class Program
 
         Loc.SetupWithFallbacks();
 
-        Dictionary<uint, string> apps = new Dictionary<uint, string>();
-        uint[] ignoredIds = { 0, STEAM_APP_ID, STEAM_APP_ID_FT };
+        Dictionary<uint, string> apps = [];
+        uint[] ignoredIds = [0, STEAM_APP_ID, STEAM_APP_ID_FT];
         if (!ignoredIds.Contains(CoreEnvironmentSettings.SteamAppId))
         {
             apps.Add(CoreEnvironmentSettings.SteamAppId, "XLM");
@@ -273,13 +275,18 @@ sealed class Program
         var version = $"{AppUtil.GetAssemblyVersion()} ({AppUtil.GetGitHash()})";
 #endif
 
-        // Create window, GraphicsDevice, and all resources necessary for the demo.
-        VeldridStartup.CreateWindowAndGraphicsDevice(
-            new WindowCreateInfo(50, 50, 1280, 800, WindowState.Normal, $"XIVLauncher {version}"),
-            new GraphicsDeviceOptions(false, null, true, ResourceBindingModel.Improved, true, true),
-            out window,
-            out gd);
-
+        // Initialise SDL, as that's needed to figure out where to spawn the window.
+        Sdl2Native.SDL_Init(SDLInitFlags.Video);
+        
+        // For now, just spawn the window on the primary display, which in SDL2 has displayIndex 0.
+        // Maybe we may want to save the window location or the preferred display in the config at some point?
+        if (!GetDisplayBounds(displayIndex: 0, out var bounds))
+            Log.Warning("Couldn't figure out the bounds of the primary display, falling back to previous assumption that (0,0) is the top left corner of the left-most monitor.");
+        
+        // Create the window and graphics device separately, because Veldrid would have reinitialised SDL if done with their combined method.
+        window = VeldridStartup.CreateWindow(new WindowCreateInfo(50 + bounds.X, 50 + bounds.Y, 1280, 800, WindowState.Normal, $"XIVLauncher {version}"));
+        gd = VeldridStartup.CreateGraphicsDevice(window, new GraphicsDeviceOptions(false, null, true, ResourceBindingModel.Improved, true, true));
+        
         window.Resized += () =>
         {
             gd.MainSwapchain.Resize((uint)window.Width, (uint)window.Height);
@@ -305,7 +312,7 @@ sealed class Program
         {
             Thread.Sleep(50);
 
-            InputSnapshot snapshot = window.PumpEvents();
+            var snapshot = window.PumpEvents();
 
             if (!window.Exists)
                 break;
@@ -347,6 +354,7 @@ sealed class Program
         }
 
         // Clean up Veldrid resources
+        // FIXME: Veldrid doesn't clean up after SDL though, so some leakage may have been happening for all this time.
         gd.WaitForIdle();
         bindings.Dispose();
         cl.Dispose();
@@ -484,4 +492,17 @@ sealed class Program
     }
 
     public static void ResetUIDCache(bool tsbutton = false) => launcherApp.UniqueIdCache.Reset();
+
+    private static unsafe bool GetDisplayBounds(int displayIndex, out Rectangle bounds)
+    {
+        bounds = new Rectangle();
+        fixed (Rectangle* rectangle = &bounds)
+        {
+            if (Sdl2Native.SDL_GetDisplayBounds(displayIndex, rectangle) != 0)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
Before simply plopping the window on (50,50), we're now checking where exactly the primary display is and offset the draw coordinates based on the display's bounds. If we don't figure out where the primary display is located, we just fall back to the prior default.

To achieve this it was necessary to break out the `VeldridStartup.CreateWindowAndGraphicsDevice()` call into two separate `VeldridStartup.CreateWindow()` and `VeldridStartup.CreateGraphicsDevice()` calls, as Veldrid would have reinitialised SDL otherwise. Since we now do the initialisation of SDL ourselves, I checked if Veldrid deinitialises regardless, but as far as I can tell, they don't bind SDL_Quit, so I have no clue how they shut down SDL in the first place, which leads me to believe that they don't and just leak the memory and handles SDL created, letting the OS deal with it. Since it's been fine for now (and I may actually be wrong about Veldrid not dealing with SDL's litter), I have put a fixme in place and left SDL unquit at application's end, instead of creating the binding for SDL_Quit and calling it. 

A proper SDL user would grab potential errors in the `Sdl2Native.SDL_GetDisplayBounds()` call with `Sdl2Native.SDL_GetError()`, but I am already logging this when the containing method returns `false` above. If you want me to log both, or only the SDL error instead, I can change that.