### PR TITLE
feat: use selectables for news items with links

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/NewsFrame.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/NewsFrame.cs
@@ -87,7 +87,7 @@ public class NewsFrame : Component
                 {
                     if (!string.IsNullOrEmpty(newsEntry.Url))
                     {
-                        if (ImGui.Selectable(newsEntry.Title) && !string.IsNullOrEmpty(newsEntry.Url))
+                        if (ImGui.Selectable(newsEntry.Title, default, default, ImGui.CalcTextSize(newsEntry.Title)) && !string.IsNullOrEmpty(newsEntry.Url))
                         {
                             AppUtil.OpenBrowser(newsEntry.Url);
                         }

--- a/src/XIVLauncher.Core/Components/MainPage/NewsFrame.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/NewsFrame.cs
@@ -46,24 +46,16 @@ public class NewsFrame : Component
         Task.Run(async () =>
         {
             this.newsLoaded = false;
-
             await Headlines.GetWorlds(this.app.Launcher, this.app.Settings.ClientLanguage ?? ClientLanguage.English).ConfigureAwait(false);
-
             bannerList = await Headlines.GetBanners(this.app.Launcher, this.app.Settings.ClientLanguage ?? ClientLanguage.English).ConfigureAwait(false);
-
             await Headlines.GetMessage(this.app.Launcher, this.app.Settings.ClientLanguage ?? ClientLanguage.English).ConfigureAwait(false);
-
             headlines = await Headlines.GetNews(this.app.Launcher, this.app.Settings.ClientLanguage ?? ClientLanguage.English).ConfigureAwait(false);
-
             this.banners = new TextureWrap[bannerList.Count];
-
-
             for (var i = 0; i < bannerList.Count; i++)
             {
                 var textureBytes = await Program.HttpClient.GetByteArrayAsync(this.bannerList[i].LsbBanner).ConfigureAwait(false);
                 this.banners[i] = TextureWrap.Load(textureBytes);
             }
-
             this.newsLoaded = true;
         });
     }
@@ -93,11 +85,16 @@ public class NewsFrame : Component
 
                 void ShowNewsEntry(News newsEntry)
                 {
-                    ImGui.TextUnformatted(newsEntry.Title);
-
-                    if (ImGui.IsItemClicked(ImGuiMouseButton.Left) && !string.IsNullOrEmpty(newsEntry.Url))
+                    if (!string.IsNullOrEmpty(newsEntry.Url))
                     {
-                        AppUtil.OpenBrowser(newsEntry.Url);
+                        if (ImGui.Selectable(newsEntry.Title) && !string.IsNullOrEmpty(newsEntry.Url))
+                        {
+                            AppUtil.OpenBrowser(newsEntry.Url);
+                        }
+                    }
+                    else
+                    {
+                        ImGui.TextUnformatted(newsEntry.Title);
                     }
                 }
 


### PR DESCRIPTION
This makes it clearer that these items can be clicked and shows which item is currently hovered.