### PR TITLE
Unpatched wine fix

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -232,16 +232,58 @@ public class CompatibilityTools
         return GetProcessIds(executableName).FirstOrDefault();
     }
 
-    public int GetUnixProcessId(int winePid)
+    public Int32 GetUnixProcessId(Int32 winePid)
     {
-        var wineDbg = RunInPrefix("winedbg --command \"info procmap\"", redirectOutput: true);
+        var environment = new Dictionary<string, string>();
+        var wineDbg = RunInPrefix("winedbg --command \"info procmap\"", redirectOutput: true, environment: environment);
         var output = wineDbg.StandardOutput.ReadToEnd();
-        if (output.Contains("syntax error\n"))
-            return 0;
+        if (output.Contains("syntax error\n") || output.Contains("Exception c0000005")) // valve wine changed the error message
+        {
+            var processName = GetProcessName(winePid);
+            return GetUnixProcessIdByName(processName);
+        }
         var matchingLines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries).Skip(1).Where(
             l => int.Parse(l.Substring(1, 8), System.Globalization.NumberStyles.HexNumber) == winePid);
         var unixPids = matchingLines.Select(l => int.Parse(l.Substring(10, 8), System.Globalization.NumberStyles.HexNumber)).ToArray();
         return unixPids.FirstOrDefault();
+    }
+
+    private string GetProcessName(Int32 winePid)
+    {
+        var environment = new Dictionary<string, string>();
+        var wineDbg = RunInPrefix("winedbg --command \"info proc\"", redirectOutput: true, environment: environment);
+        var output = wineDbg.StandardOutput.ReadToEnd();
+        var matchingLines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries).Skip(1).Where(
+            l => int.Parse(l.Substring(1, 8), System.Globalization.NumberStyles.HexNumber) == winePid);
+        var processNames = matchingLines.Select(l => l.Substring(20).Trim('\'')).ToArray();
+        return processNames.FirstOrDefault();
+    }
+
+    private Int32 GetUnixProcessIdByName(string executableName)
+    {
+        int closest = 0;
+        int early = 0;
+        var currentProcess = Process.GetCurrentProcess(); // Gets XIVLauncher.Core's process
+        bool nonunique = false;
+        foreach (var process in Process.GetProcessesByName(executableName))
+        {
+            if (process.Id < currentProcess.Id)
+            {
+                early = process.Id;
+                continue;  // Process was launched before XIVLauncher.Core
+            }
+            // Assume that the closest PID to XIVLauncher.Core's is the correct one. But log an error if more than one is found.
+            if ((closest - currentProcess.Id) > (process.Id - currentProcess.Id) || closest == 0)
+            {
+                if (closest != 0) nonunique = true;
+                closest = process.Id;
+            }
+            if (nonunique) Log.Error($"More than one {executableName} found! Selecting the most likely match with process id {closest}.");
+        }
+        // Deal with rare edge-case where pid rollover causes the ffxiv pid to be lower than XLCore's.
+        if (closest == 0 && early != 0) closest = early;
+        if (closest != 0) Log.Verbose($"Process for {executableName} found using fallback method: {closest}. XLCore pid: {currentProcess.Id}");
+        return closest;
     }
 
     public string UnixToWinePath(string unixPath)

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -234,8 +234,7 @@ public class CompatibilityTools
 
     public Int32 GetUnixProcessId(Int32 winePid)
     {
-        var environment = new Dictionary<string, string>();
-        var wineDbg = RunInPrefix("winedbg --command \"info procmap\"", redirectOutput: true, environment: environment);
+        var wineDbg = RunInPrefix("winedbg --command \"info procmap\"", redirectOutput: true);
         var output = wineDbg.StandardOutput.ReadToEnd();
         if (output.Contains("syntax error\n") || output.Contains("Exception c0000005")) // valve wine changed the error message
         {
@@ -250,8 +249,7 @@ public class CompatibilityTools
 
     private string GetProcessName(Int32 winePid)
     {
-        var environment = new Dictionary<string, string>();
-        var wineDbg = RunInPrefix("winedbg --command \"info proc\"", redirectOutput: true, environment: environment);
+        var wineDbg = RunInPrefix("winedbg --command \"info proc\"", redirectOutput: true);
         var output = wineDbg.StandardOutput.ReadToEnd();
         var matchingLines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries).Skip(1).Where(
             l => int.Parse(l.Substring(1, 8), System.Globalization.NumberStyles.HexNumber) == winePid);

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -232,7 +232,7 @@ public class CompatibilityTools
         return GetProcessIds(executableName).FirstOrDefault();
     }
 
-    public Int32 GetUnixProcessId(Int32 winePid)
+    public int GetUnixProcessId(int winePid)
     {
         var wineDbg = RunInPrefix("winedbg --command \"info procmap\"", redirectOutput: true);
         var output = wineDbg.StandardOutput.ReadToEnd();
@@ -247,7 +247,7 @@ public class CompatibilityTools
         return unixPids.FirstOrDefault();
     }
 
-    private string GetProcessName(Int32 winePid)
+    private string GetProcessName(int winePid)
     {
         var wineDbg = RunInPrefix("winedbg --command \"info proc\"", redirectOutput: true);
         var output = wineDbg.StandardOutput.ReadToEnd();
@@ -257,7 +257,7 @@ public class CompatibilityTools
         return processNames.FirstOrDefault();
     }
 
-    private Int32 GetUnixProcessIdByName(string executableName)
+    private int GetUnixProcessIdByName(string executableName)
     {
         int closest = 0;
         int early = 0;

--- a/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
@@ -74,12 +74,28 @@ public class UnixDalamudRunner : IDalamudRunner
         launchArguments.Add(gameArgs);
 
         var dalamudProcess = compatibility.RunInPrefix(string.Join(" ", launchArguments), environment: environment, redirectOutput: true, writeLog: true);
-        var output = dalamudProcess.StandardOutput.ReadLine();
 
-        if (output == null)
-            throw new DalamudRunnerException("An internal Dalamud error has occured");
+        DalamudConsoleOutput dalamudConsoleOutput = null;
+        int invalidJsonCount = 0;
 
-        Console.WriteLine(output);
+        // Keep checking for valid json output, but only 5 times. If it's still erroring out at that point, give up.
+        while (dalamudConsoleOutput == null && invalidJsonCount < 5)
+        {
+            var output = dalamudProcess.StandardOutput.ReadLine();
+            if (output == null)
+                throw new DalamudRunnerException("An internal Dalamud error has occured");
+            Console.WriteLine(output);
+
+            try
+            {
+                dalamudConsoleOutput = JsonConvert.DeserializeObject<DalamudConsoleOutput>(output);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, $"Couldn't parse Dalamud output: {output}");
+            }
+            invalidJsonCount++;
+        }
 
         new Thread(() =>
         {
@@ -94,12 +110,11 @@ public class UnixDalamudRunner : IDalamudRunner
 
         try
         {
-            var dalamudConsoleOutput = JsonConvert.DeserializeObject<DalamudConsoleOutput>(output);
             var unixPid = compatibility.GetUnixProcessId(dalamudConsoleOutput.Pid);
 
             if (unixPid == 0)
             {
-                Log.Error("Could not retrive Unix process ID, this feature currently requires a patched wine version");
+                Log.Error("Could not retrieve Unix process ID");
                 return null;
             }
 
@@ -107,9 +122,9 @@ public class UnixDalamudRunner : IDalamudRunner
             Log.Verbose($"Got game process handle {gameProcess.Handle} with Unix pid {gameProcess.Id} and Wine pid {dalamudConsoleOutput.Pid}");
             return gameProcess;
         }
-        catch (JsonReaderException ex)
+        catch (Exception ex)
         {
-            Log.Error(ex, $"Couldn't parse Dalamud output: {output}");
+            Log.Error(ex, $"Could not retrieve game Process information");
             return null;
         }
     }


### PR DESCRIPTION
If running patched valve-wine, the dalamud injector may occasionally spit out an error about not finding a video device before spitting out the expeced winePid JSON. This will prevent the process ID from being found. Added a loop to try checking a few more times before failing.

If `info procmap` fails (due to wine being unpatched), we will try to find the process by name. This prevents the xlcore process from hanging with unpatched wine. This is currently not a big issue since current unpatched wine simply crashes dalamud, but it may become relevant when the debug helper code gets fixed.

This is all ported over from the previous compatibility-rework-2.