### PR TITLE
feat: automatically use steam install path in compat tool

### DIFF
--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDebug.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDebug.cs
@@ -19,9 +19,6 @@ public class SettingsTabDebug : SettingsTab
         if (Program.IsSteamDeckHardware)
             ImGui.Text("Steam Deck Hardware Detected");
 
-        if (Program.IsSteamDeckGamingMode)
-            ImGui.Text("Steam Deck Gaming Mode Detected");
-
 #if FLATPAK
             ImGui.Text("Running as a Flatpak");
 #endif
@@ -36,7 +33,7 @@ public class SettingsTabDebug : SettingsTab
             ImGui.TableSetupColumn("Key", ImGuiTableColumnFlags.WidthStretch, 0.35f);
             ImGui.TableSetupColumn("Value");
             ImGui.TableHeadersRow();
-            foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+            foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables().Cast<DictionaryEntry>().OrderBy(entry => entry.Key.ToString()))
             {
                 ImGui.TableNextRow();
                 ImGui.TableNextColumn();


### PR DESCRIPTION
This allows for XLM to automatically use the Steam install path by default for new users. 

I also cleaned up the steamdeck gaming mode check because it's unused and sorted the debug env list because I was using that for testing