### PR TITLE
Do not Create Compat Tools on Windows at startup

### DIFF
--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -127,7 +127,6 @@ public class SettingsTabWine : SettingsTab
     public override void Save()
     {
         base.Save();
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            Program.CreateCompatToolsInstance();
+        Program.CreateCompatToolsInstance();
     }
 }

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -1,5 +1,3 @@
-using System.Numerics;
-
 using CheapLoc;
 
 using Config.Net;
@@ -7,6 +5,9 @@ using Config.Net;
 using ImGuiNET;
 
 using Serilog;
+
+using System.Numerics;
+using System.Runtime.InteropServices;
 
 using Veldrid;
 using Veldrid.Sdl2;
@@ -375,6 +376,7 @@ sealed class Program
 
     public static void CreateCompatToolsInstance()
     {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
         var wineLogFile = new FileInfo(Path.Combine(storage.GetFolder("logs").FullName, "wine.log"));
         var winePrefix = storage.GetFolder("wineprefix");
         var wineSettings = new WineSettings(Config.WineStartupType ?? WineStartupType.Custom, Config.WineManagedVersion ?? WineManagedVersion.Stable, Config.WineBinaryPath, Config.WineDebugVars, wineLogFile, winePrefix, Config.ESyncEnabled ?? true, Config.FSyncEnabled ?? false);


### PR DESCRIPTION
Fixes a regression in https://github.com/goatcorp/XIVLauncher.Core/pull/221 by copying
https://github.com/goatcorp/XIVLauncher.Core/blob/a5262bda5a8a922b3da8b9ce6d977e2376151706/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs#L130-L131
Into the target function directly, enabling the launcher to start on Windows again.
There was an existing issue that caused the launcher to crash when hitting the `Clear Wine & DXVK` button on the troubleshooting tab due to a file handler not being cleared, but this stopped being an issue with the new uncaught error


I'm unsure if this is replicated for other users, but the game is unable to launch with Dalamud with a Generic Exception(-2146233069). While I'm certain this isn't a new regression by this patch, it might be important to note in case that it is. I haven't taken too much time to look at it, but both that the dalamud runner isn't a part of this repo and that players are discouraged from actually using this over the main application, it might not be as important as this issue alone, especially as the game runs fine standalone