### PR TITLE
Add checksums for compat tools, ship unofficial wine 10

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatUtil.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatUtil.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 
 namespace XIVLauncher.Common.Unix.Compatibility.Wine;
 
@@ -87,5 +89,17 @@ public static class CompatUtil
         {
             return WineReleaseDistro.ubuntu;
         }
+    }
+
+    public static bool EnsureChecksumMatch(string filePath, string[] checksums)
+    {
+        if (checksums.Length == 0)
+        {
+            return false;
+        }
+        using var sha512 = SHA512.Create();
+        using var stream = File.OpenRead(filePath);
+        var computedHash = Convert.ToHexString(sha512.ComputeHash(stream)).ToLowerInvariant();
+        return checksums.Any(checksum => string.Equals(checksum, computedHash, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -96,13 +96,13 @@ public class CompatibilityTools
     {
         using var client = new HttpClient();
         var tempFilePath = Path.Combine(tempPath.FullName, $"{Guid.NewGuid()}");
-
         await File.WriteAllBytesAsync(tempFilePath, await client.GetByteArrayAsync(Settings.WineRelease.DownloadUrl).ConfigureAwait(false)).ConfigureAwait(false);
-
+        if (!CompatUtil.EnsureChecksumMatch(tempFilePath, Settings.WineRelease.Checksums))
+        {
+            throw new InvalidDataException("SHA512 checksum verification failed");
+        }
         PlatformHelpers.Untar(tempFilePath, this.wineDirectory.FullName);
-
         Log.Information("Compatibility tool successfully extracted to {Path}", this.wineDirectory.FullName);
-
         File.Delete(tempFilePath);
     }
 

--- a/src/XIVLauncher.Common.Unix/Compatibility/Dxvk/IDxvkRelease.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Dxvk/IDxvkRelease.cs
@@ -2,6 +2,7 @@ namespace XIVLauncher.Common.Unix.Compatibility.Dxvk;
 
 public interface IDxvkRelease
 {
-    public string Name { get; }
-    public string DownloadUrl { get; }
+    string Name { get; }
+    string DownloadUrl { get; }
+    string Checksum { get; }
 }

--- a/src/XIVLauncher.Common.Unix/Compatibility/Dxvk/Releases/DxvkLegacy.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Dxvk/Releases/DxvkLegacy.cs
@@ -4,4 +4,5 @@ public sealed class DxvkLegacyRelease : IDxvkRelease
 {
     public string Name { get; } = "dxvk-async-1.10.3";
     public string DownloadUrl { get; } = "https://github.com/Sporif/dxvk-async/releases/download/1.10.3/dxvk-async-1.10.3.tar.gz";
+    public string Checksum { get; } = "afc856b859f1c36d919055e471ae1dd1900424ea42139ab8c1ae231fe9617234d1dfa53f6bf0e5d183575a224f2b8bc950f258108607f39cc419823d68f06ff2";
 }

--- a/src/XIVLauncher.Common.Unix/Compatibility/Dxvk/Releases/DxvkStable.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Dxvk/Releases/DxvkStable.cs
@@ -4,4 +4,5 @@ public sealed class DxvkStableRelease : IDxvkRelease
 {
     public string Name { get; } = "dxvk-gplasync-v2.6.1-1";
     public string DownloadUrl { get; } = "https://gitlab.com/Ph42oN/dxvk-gplasync/-/raw/8a55443c13a5c8b0a09b6859edaa54e3576518b3/releases/dxvk-gplasync-v2.6.1-1.tar.gz";
+    public string Checksum { get; } = "4196972aa26ffd7da94542fef065bdb2a4a0926498fe4834ef75f43dd2a8c393db8b0edffa21a2906f664a99679cfea4c371c5a9577eb025410b76d63df8a872";
 }

--- a/src/XIVLauncher.Common.Unix/Compatibility/Wine/IWineRelease.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Wine/IWineRelease.cs
@@ -4,4 +4,5 @@ public interface IWineRelease
 {
     string Name { get; }
     string DownloadUrl { get; }
+    string[] Checksums { get; }
 }

--- a/src/XIVLauncher.Common.Unix/Compatibility/Wine/Releases/WineLegacy.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Wine/Releases/WineLegacy.cs
@@ -4,4 +4,9 @@ public sealed class WineLegacyRelease(WineReleaseDistro wineDistroId) : IWineRel
 {
     public string Name { get; } = $"wine-xiv-staging-fsync-git-8.5.r4.g4211bac7";
     public string DownloadUrl { get; } = $"https://github.com/goatcorp/wine-xiv-git/releases/download/8.5.r4.g4211bac7/wine-xiv-staging-fsync-git-{wineDistroId}-8.5.r4.g4211bac7.tar.xz";
+    public string[] Checksums { get; } = [
+        "832de4d834bdbd6e1e069f13efcb56fa1508c9d7ba0609e1161a52d814f2c6f7c89c8e2d1bcff05da7f0b5cab0662f7e5d57865ab7a5c9d144e6bd55051adee5", // wine-xiv-staging-fsync-git-fedora-8.5.r4.g4211bac7.tar.xz
+        "5158108788f21f03c895216265824eba0080c6aceacd901a1f60e242ed161db2d6cb65304bbc0187310b08513df2a5c40c62a41838ac1765a422f85387109930", // wine-xiv-staging-fsync-git-ubuntu-8.5.r4.g4211bac7.tar.xz
+        "ff77e19d35c598bc5602222d4bb4c0b85ae375f99f9ae0000f847a904ef80c120d89e59da921ee05fe54b0bd583e9cf1fb7f142b95f3ad2d3aba9891b6605f08"  // wine-xiv-staging-fsync-git-arch-8.5.r4.g4211bac7.tar.xz
+    ];
 }

--- a/src/XIVLauncher.Common.Unix/Compatibility/Wine/Releases/WineStable.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Wine/Releases/WineStable.cs
@@ -1,8 +1,12 @@
 namespace XIVLauncher.Common.Unix.Compatibility.Wine.Releases;
 
-// Change paths as appropriate for a new stable wine release.
 public sealed class WineStableRelease(WineReleaseDistro wineDistroId) : IWineRelease
 {
-    public string Name { get; } = $"wine-xiv-staging-fsync-git-10.5.r0.g835c92a2";
-    public string DownloadUrl { get; } = $"https://github.com/rankynbass/unofficial-wine-xiv-git/releases/download/10.5.r0.g835c92a2/wine-xiv-staging-fsync-git-{wineDistroId}-10.5.r0.g835c92a2.tar.xz";
+    public string Name { get; } = $"unofficial-wine-xiv-staging-10.8";
+    public string DownloadUrl { get; } = $"https://github.com/rankynbass/unofficial-wine-xiv-git/releases/download/v10.8/unofficial-wine-xiv-staging-{wineDistroId}-10.8.tar.xz";
+    public string[] Checksums { get; } = [
+        "fbd78d16d94c9d5a0a43ffa8c8d0107c2f69f6956aab19e2449a5e8de762e9e9c6eb60fd82bfc5c85969a603773ff368abe13cd8c923d9ab4302fa3bdb1a8406", // unofficial-wine-xiv-staging-arch-10.8.tar.xz
+        "3ea54e93990643273cb1fc866324cf8f7fcce8bb8b0f1bf3e45d6e3fb4ba38c765dd79312bde9586bd6c345d76d8382076876bb05408893cb1bd1f19640f1683", // unofficial-wine-xiv-staging-fedora-10.8.tar.xz
+        "578a1883d1820209dca70d4775544d7354aa3a05d762d6e044e5de23d43892f6800424e295da36c1589d0566ebb553b3e48b2f099559660033a69a5e544a6165"  // unofficial-wine-xiv-staging-ubuntu-10.8.tar.xza
+    ];
 }

--- a/src/XIVLauncher.Common.Unix/Compatibility/Wine/WineSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Wine/WineSettings.cs
@@ -14,20 +14,13 @@ public enum WineStartupType
     Custom,
 }
 
-// Uncomment this enum and delete the one below when a new stable wine is released.
-// public enum WineManagedVersion
-// {
-//     [SettingsDescription("Stable", "Based on Wine 10.5 - recommended for most users.")]
-//     Stable,
-//
-//     [SettingsDescription("Legacy", "Based on Wine 8.5 - use for compatibility with some plugins.")]
-//     Legacy,
-// }
-//
 public enum WineManagedVersion
 {
-    [SettingsDescription("Stable", "Current release based on Wine 8.5")]
+    [SettingsDescription("Stable", "Based on Wine 10.8 - recommended for most users.")]
     Stable,
+
+    [SettingsDescription("Legacy", "Based on Wine 8.5 - use for compatibility with some plugins.")]
+    Legacy,
 }
 
 public class WineSettings
@@ -47,20 +40,17 @@ public class WineSettings
         this.StartupType = startupType;
 
         var wineDistroId = CompatUtil.GetWineIdForDistro();
-        // Uncomment below once a new stable wine is released.
-        // switch (managedWine)
-        // {
-        //     case WineManagedVersion.Stable:
-        //         this.WineRelease = new WineStableRelease(wineDistroId);
-        //         break;
-        //     case WineManagedVersion.Legacy:
-        //         this.WineRelease = new WineLegacyRelease(wineDistroId);
-        //         break;
-        //     default:
-        //         throw new ArgumentOutOfRangeException(managedWine.ToString());
-        // }
-        // Delete the next line once a new stable wine is released.
-        this.WineRelease = new WineLegacyRelease(wineDistroId);
+        switch (managedWine)
+        {
+            case WineManagedVersion.Stable:
+                this.WineRelease = new WineStableRelease(wineDistroId);
+                break;
+            case WineManagedVersion.Legacy:
+                this.WineRelease = new WineLegacyRelease(wineDistroId);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(managedWine.ToString());
+        }
         this.CustomBinPath = customBinPath;
         this.EsyncOn = esyncOn ? "1" : "0";
         this.FsyncOn = fsyncOn ? "1" : "0";

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -22,12 +22,11 @@ public class SettingsTabWine : SettingsTab
             startupTypeSetting = new SettingsEntry<WineStartupType>("Wine Version", "Choose how XIVLauncher will start and manage your wine installation.",
                 () => Program.Config.WineStartupType ?? WineStartupType.Managed, x => Program.Config.WineStartupType = x),
 
-            // Uncomment this section once a new wine version is released.
-            // new SettingsEntry<WineManagedVersion>("Wine Release", "If you change wine releases, you might have to clear your prefix (Troubleshooting tab)", () => Program.Config.WineManagedVersion ?? WineManagedVersion.Stable,
-            //     x => Program.Config.WineManagedVersion = x )
-            // {
-            //     CheckVisibility = () => startupTypeSetting.Value == WineStartupType.Managed
-            // },
+            new SettingsEntry<WineManagedVersion>("Wine Release", "If you change wine releases, you might have to clear your prefix (Troubleshooting tab)", () => Program.Config.WineManagedVersion ?? WineManagedVersion.Stable,
+                x => Program.Config.WineManagedVersion = x )
+            {
+                CheckVisibility = () => startupTypeSetting.Value == WineStartupType.Managed
+            },
 
             new SettingsEntry<string>("Wine Binary Path",
                 "Set the path XIVLauncher will use to run applications via wine.\nIt should be an absolute path to a folder containing wine64 and wineserver binaries.",


### PR DESCRIPTION
Adds checksum verification for wine and dxvk downloads for better security, this also opens the door to shipping unofficial (non-goatcorp) versions of wine as long as they've been vetted beforehand. After testing @rankynbass's unofficial wine-xiv 10.8 for a good while I've decided to also include that as our new stable version