### PR TITLE
align version number with semver

### DIFF
--- a/src/XIVLauncher.Core/XIVLauncher.Core.csproj
+++ b/src/XIVLauncher.Core/XIVLauncher.Core.csproj
@@ -9,7 +9,7 @@
         <LangVersion>latest</LangVersion>
         <ApplicationIcon>Resources\dalamud_icon.ico</ApplicationIcon>
 
-        <Version>1.1.3.0</Version>
+        <Version>1.2.0</Version>
         <FileVersion>$(Version)</FileVersion>
         <AssemblyVersion>$(Version)</AssemblyVersion>
 


### PR DESCRIPTION
Removes the trailing `0` (unused in tags, useless anyway) and updates the minor version