### PR TITLE
Add a fixed wine release (-nolsc)

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/Wine/Releases/WineLSteamClient.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Wine/Releases/WineLSteamClient.cs
@@ -1,0 +1,12 @@
+namespace XIVLauncher.Common.Unix.Compatibility.Wine.Releases;
+
+public sealed class WineLSteamClientRelease(WineReleaseDistro wineDistroId) : IWineRelease
+{
+    public string Name { get; } = $"wine-xiv-staging-fsync-git-10.8.r0.g47f77594";
+    public string DownloadUrl { get; } = $"https://github.com/goatcorp/wine-xiv-git/releases/download/10.8.r0.g47f77594/wine-xiv-staging-fsync-git-{wineDistroId}-10.8.r0.g47f77594.tar.xz";
+    public string[] Checksums { get; } = [
+        "fac545a5d8ee219bf622903adb7a5ca6f2f968d9a2307da3f0ec394dde08c4d4f956487f4b326ef1cfc92eaface463f270f590695ad8874d5c88028fac8f6250", // wine-xiv-staging-fsync-git-arch-10.8.r0.g47f77594.tar.xz
+        "c6857467ea3da9d7071164c89c87838dd1ff6006406e2ba24516bef3ea0c701386b26f68752b20710464410d62846ceea1c69f78caf777dbafc611daa7fba6c9",  // wine-xiv-staging-fsync-git-fedora-10.8.r0.g47f77594.tar.xz
+        "fb0bf85190ec9d001e39135537f27f82e8bd0ab1f222c008012128fbb6f6d8c8547f1315d09d909e7219fe2c221005a5b98927bfb95a24a36c5fca526ae0e95b" // wine-xiv-staging-fsync-git-ubuntu-10.8.r0.g47f77594.tar.xz
+    ];
+}

--- a/src/XIVLauncher.Common.Unix/Compatibility/Wine/Releases/WineStable.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Wine/Releases/WineStable.cs
@@ -2,11 +2,11 @@ namespace XIVLauncher.Common.Unix.Compatibility.Wine.Releases;
 
 public sealed class WineStableRelease(WineReleaseDistro wineDistroId) : IWineRelease
 {
-    public string Name { get; } = $"wine-xiv-staging-fsync-git-10.8.r0.g47f77594";
-    public string DownloadUrl { get; } = $"https://github.com/goatcorp/wine-xiv-git/releases/download/10.8.r0.g47f77594/wine-xiv-staging-fsync-git-{wineDistroId}-10.8.r0.g47f77594.tar.xz";
+    public string Name { get; } = $"wine-xiv-staging-fsync-git-10.8.r0.g47f77594-nolsc";
+    public string DownloadUrl { get; } = $"https://github.com/goatcorp/wine-xiv-git/releases/download/10.8.r0.g47f77594/wine-xiv-staging-fsync-git-{wineDistroId}-10.8.r0.g47f77594-nolsc.tar.xz";
     public string[] Checksums { get; } = [
-        "fac545a5d8ee219bf622903adb7a5ca6f2f968d9a2307da3f0ec394dde08c4d4f956487f4b326ef1cfc92eaface463f270f590695ad8874d5c88028fac8f6250", // wine-xiv-staging-fsync-git-arch-10.8.r0.g47f77594.tar.xz
-        "c6857467ea3da9d7071164c89c87838dd1ff6006406e2ba24516bef3ea0c701386b26f68752b20710464410d62846ceea1c69f78caf777dbafc611daa7fba6c9",  // wine-xiv-staging-fsync-git-fedora-10.8.r0.g47f77594.tar.xz
-        "fb0bf85190ec9d001e39135537f27f82e8bd0ab1f222c008012128fbb6f6d8c8547f1315d09d909e7219fe2c221005a5b98927bfb95a24a36c5fca526ae0e95b" // wine-xiv-staging-fsync-git-ubuntu-10.8.r0.g47f77594.tar.xz
+        "e7803fff77cec837f604eef15af8434b4d74acd0e3adf1885049b31143bdd6b69f03f56b14f078e501f42576b3b4434deca547294b2ded0c471720ef7e412367", // wine-xiv-staging-fsync-git-arch-10.8.r0.g47f77594-nolsc.tar.xz
+        "7475788ba4cd448743fa44acba475eac796c9fe1ec8a2b37e0fdb7123cf3feac0c97f0a4e43ea023bf1e70853e7916a5a27e835fc5f651ac5c08040251bc4522",  // wine-xiv-staging-fsync-git-fedora-10.8.r0.g47f77594-nolsc.tar.xz
+        "9d06e403b0b879a7b1f6394d69a6d23ee929c27f1f7a3abbf0f34fab3cbaff0b8154849d406f3ed15ee62ec0444379173070da208607fadabbf65186ed0cbf95" // wine-xiv-staging-fsync-git-ubuntu-10.8.r0.g47f77594-nolsc.tar.xz
     ];
 }

--- a/src/XIVLauncher.Common.Unix/Compatibility/Wine/WineSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Wine/WineSettings.cs
@@ -19,6 +19,9 @@ public enum WineManagedVersion
     [SettingsDescription("Stable", "Based on Wine 10.8 - recommended for most users.")]
     Stable,
 
+    [SettingsDescription("LSteamClient", "Based on Wine 10.8 with lsteamclient patches. Better Steam integration.")]
+    LSteamClient,
+
     [SettingsDescription("Legacy", "Based on Wine 8.5 - use for compatibility with some plugins.")]
     Legacy,
 }
@@ -44,6 +47,9 @@ public class WineSettings
         {
             case WineManagedVersion.Stable:
                 this.WineRelease = new WineStableRelease(wineDistroId);
+                break;
+            case WineManagedVersion.LSteamClient:
+                this.WineRelease = new WineLSteamClientRelease(wineDistroId);
                 break;
             case WineManagedVersion.Legacy:
                 this.WineRelease = new WineLegacyRelease(wineDistroId);

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -19,7 +19,7 @@ public class SettingsTabWine : SettingsTab
     {
         Entries = new SettingsEntry[]
         {
-            startupTypeSetting = new SettingsEntry<WineStartupType>("Wine Version", "Choose how XIVLauncher will start and manage your wine installation.",
+            startupTypeSetting = new SettingsEntry<WineStartupType>("Wine Install", "Choose how XIVLauncher will start and manage your wine installation.",
                 () => Program.Config.WineStartupType ?? WineStartupType.Managed, x => Program.Config.WineStartupType = x),
 
             new SettingsEntry<WineManagedVersion>("Wine Version", "If you change wine releases, you might have to clear your prefix (Troubleshooting tab)", () => Program.Config.WineManagedVersion ?? WineManagedVersion.Stable,


### PR DESCRIPTION
The -nolsc wine releases disable the lsteamclient patches and remove the lsteamclient.dll/.so files. This seems to fix some input issues on the steam deck and with PS4/5 controllers. 
 
* Set the new version as Stable - probably safest for steam deck users
* Set the original 10.8 as LSteamClient - keep this version around in case the new version causes input issues for other people.
* Rename Wine Version (managed/custom) to Wine Install to prevent having two Wine Versions in Settings.

Tested on arch, fedora, ubuntu to make sure the files would download properly. Everyting worked.