### PR TITLE
fix: temporarily mirror dxvk to xlcore-distrib

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/Dxvk/Releases/DxvkStable.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Dxvk/Releases/DxvkStable.cs
@@ -3,6 +3,6 @@ namespace XIVLauncher.Common.Unix.Compatibility.Dxvk.Releases;
 public sealed class DxvkStableRelease : IDxvkRelease
 {
     public string Name { get; } = "dxvk-gplasync-v2.6.1-1";
-    public string DownloadUrl { get; } = "https://gitlab.com/Ph42oN/dxvk-gplasync/-/raw/8a55443c13a5c8b0a09b6859edaa54e3576518b3/releases/dxvk-gplasync-v2.6.1-1.tar.gz";
+    public string DownloadUrl { get; } = "https://raw.githubusercontent.com/goatcorp/xlcore-distrib/refs/heads/main/dxvk-gplasync-v2.6.1-1.tar.gz";
     public string Checksum { get; } = "4196972aa26ffd7da94542fef065bdb2a4a0926498fe4834ef75f43dd2a8c393db8b0edffa21a2906f664a99679cfea4c371c5a9577eb025410b76d63df8a872";
 }

--- a/src/XIVLauncher.Common.Unix/Compatibility/Wine/WineSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Wine/WineSettings.cs
@@ -16,11 +16,11 @@ public enum WineStartupType
 
 public enum WineManagedVersion
 {
-    [SettingsDescription("Beta", "Testing ground for the newest wine changes. Based on Wine 10.8 with lsteamclient patches.")]
-    Beta,
-
     [SettingsDescription("Stable", "Based on Wine 10.8 - recommended for most users.")]
     Stable,
+
+    [SettingsDescription("Beta", "Testing ground for the newest wine changes. Based on Wine 10.8 with lsteamclient patches.")]
+    Beta,
 
     [SettingsDescription("Legacy", "Based on Wine 8.5 - use for compatibility with some plugins.")]
     Legacy,


### PR DESCRIPTION
Users had issues downloading the new build from GitLab so it's been moved to a temporary repo until we figure out a better way of hosting things