### PR TITLE
Fix stablewine prefix error

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -89,7 +89,6 @@ public class CompatibilityTools
 
         if (Settings.WineRelease is not WineBetaRelease || Settings.StartupType == WineStartupType.Custom)
         {
-            Console.WriteLine("LSTEAMCLIENT: deleting from prefix");
             var lsteamclient = new FileInfo(Path.Combine(Settings.Prefix.FullName, "drive_c", "windows", "system32", "lsteamclient.dll"));
             lsteamclient.Delete();
         }

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -90,7 +90,7 @@ public class CompatibilityTools
         if (Settings.WineRelease is not WineBetaRelease || Settings.StartupType == WineStartupType.Custom)
         {
             var lsteamclient = new FileInfo(Path.Combine(Settings.Prefix.FullName, "drive_c", "windows", "system32", "lsteamclient.dll"));
-            lsteamclient.Delete();
+            if (lsteamclient.Exists) lsteamclient.Delete();
         }
 
         EnsurePrefix();

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -11,6 +11,7 @@ using Serilog;
 
 using XIVLauncher.Common.Unix.Compatibility.Dxvk;
 using XIVLauncher.Common.Unix.Compatibility.Wine;
+using XIVLauncher.Common.Unix.Compatibility.Wine.Releases;
 using XIVLauncher.Common.Util;
 
 namespace XIVLauncher.Common.Unix.Compatibility;
@@ -86,7 +87,15 @@ public class CompatibilityTools
             await DownloadTool(tempPath).ConfigureAwait(false);
         }
 
+        if (Settings.WineRelease is not WineBetaRelease || Settings.StartupType == WineStartupType.Custom)
+        {
+            Console.WriteLine("LSTEAMCLIENT: deleting from prefix");
+            var lsteamclient = new FileInfo(Path.Combine(Settings.Prefix.FullName, "drive_c", "windows", "system32", "lsteamclient.dll"));
+            lsteamclient.Delete();
+        }
+
         EnsurePrefix();
+
         await Dxvk.Dxvk.InstallDxvk(Settings.Prefix, dxvkDirectory, dxvkVersion).ConfigureAwait(false);
 
         IsToolReady = true;


### PR DESCRIPTION
When switching from Beta to Stable or Legacy (or custom wine without lsteamclient), the wine prefix will be broken. This is because the lsteamclient.dll in system32 will not have any backing files in the lib/wine/x86_64-unix or lib/wine/x86_64-windows folders, so when Dalamud tries to load it, it crashes.

This patch checks to see if we're not using Beta wine or are using custom wine, and then deletes the lsteamclient.dll if so. It does this before ensuring the prefix, so if the custom wine does contain lsteamclient, it will regenerate the lsteamclient.dll when ensuring the prefix.