### PR TITLE
allow override of Steam AppID to FFXIV IDs

### DIFF
--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -197,17 +197,22 @@ sealed class Program
         Loc.SetupWithFallbacks();
 
         Dictionary<uint, string> apps = [];
-        uint[] ignoredIds = [0, STEAM_APP_ID, STEAM_APP_ID_FT];
-        if (!ignoredIds.Contains(CoreEnvironmentSettings.SteamAppId))
+        if (CoreEnvironmentSettings.SteamAppId != 0)
         {
             apps.Add(CoreEnvironmentSettings.SteamAppId, "XLM");
         }
-        if (!ignoredIds.Contains(CoreEnvironmentSettings.AltAppID))
+        if (CoreEnvironmentSettings.AltAppID != 0)
         {
             apps.Add(CoreEnvironmentSettings.AltAppID, "XL_APPID");
         }
-        apps.Add(STEAM_APP_ID, "FFXIV Retail");
-        apps.Add(STEAM_APP_ID_FT, "FFXIV Free Trial");
+        if (!apps.ContainsKey(STEAM_APP_ID))
+        {
+            apps.Add(STEAM_APP_ID, "FFXIV Retail");
+        }
+        if (!apps.ContainsKey(STEAM_APP_ID_FT))
+        {
+            apps.Add(STEAM_APP_ID_FT, "FFXIV Free Trial");
+        }
         try
         {
             switch (Environment.OSVersion.Platform)


### PR DESCRIPTION
Prior to ebc8bcebc67050cf252b37cb3076b5c14e3c661d it was possible to set Steam AppID to Free Trial by selecting the global "free trial" option. The new per-account setting removed the if/else branch that made that possible, and now Retail ID is always prioritized. This creates an unintuitive experience for non-Steam players (on SteamDeck, for example) who have a family member owning a Steam edition of FFXIV, where the game will always pick Retail AppID instead of Free Trial, regardless if the user has Retail installed or not. That's not only unintuitive but it also prevents Steam edition owning family member from launching the game at the same time.

The current workaround for this is to set XL_APPID to a non-FFXIV ID, which is rather hacky and means the player is forced to set FFXIV controller layout to whatever game was picked.

To improve the experience, this patch changes the AppID priority order logic, so that SteamAppID or XL_APPID environment variables can be used to give Retail/FT IDs a higher priority when attempting to select which AppID to use.