### PR TITLE
Wine release fixes

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatUtil.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatUtil.cs
@@ -42,10 +42,6 @@ public static class CompatUtil
                     osInfo.Add(keyValue[0], keyValue[1]);
             }
 
-            var name = (osInfo.ContainsKey("NAME") ? osInfo["NAME"] : "").Trim('"');
-            var pretty = (osInfo.ContainsKey("PRETTY_NAME") ? osInfo["PRETTY_NAME"] : "").Trim('"');
-            name = pretty == "" ? (name == "" ? "Unknown distribution" : name) : pretty;
-
             // Check for flatpak or snap
             if (osInfo.ContainsKey("ID"))
             {

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatUtil.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatUtil.cs
@@ -65,19 +65,17 @@ public static class CompatUtil
             // Check for values in osInfo.
             foreach (var kvp in osInfo)
             {
-                if (kvp.Value.ToLower().Contains("fedora"))
+                if (kvp.Value.ToLower().Contains("fedora") || kvp.Value.ToLower().Contains("tumbleweed"))
                 {
                     return WineReleaseDistro.fedora;
                 }
-                else if (kvp.Value.ToLower().Contains("tumbleweed"))
-                {
-                    return WineReleaseDistro.fedora;
-                }
-                else if (kvp.Value.ToLower().Contains("arch"))
+
+                if (kvp.Value.ToLower().Contains("arch"))
                 {
                     return WineReleaseDistro.arch;
                 }
-                else if (kvp.Value.ToLower().Contains("ubuntu") || kvp.Value.ToLower().Contains("debian"))
+
+                if (kvp.Value.ToLower().Contains("ubuntu") || kvp.Value.ToLower().Contains("debian"))
                 {
                     return WineReleaseDistro.ubuntu;
                 }

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatUtil.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatUtil.cs
@@ -12,21 +12,27 @@ public enum WineReleaseDistro
     ubuntu,
     fedora,
     arch,
+    macOS
 }
 
 public static class CompatUtil
 {
-    private const string OS_RELEASE_PATH = "/etc/os-release";
-
     public static WineReleaseDistro GetWineIdForDistro()
     {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return WineReleaseDistro.macOS;
+        }
+        
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            throw new InvalidOperationException("GetWineIdForDistro can only be called on the Linux platform");
+            throw new InvalidOperationException("GetWineIdForDistro called on unsupported platform");
         }
 
         try
         {
+            const string OS_RELEASE_PATH = "/etc/os-release";
+
             if (!File.Exists(OS_RELEASE_PATH))
             {
                 return WineReleaseDistro.ubuntu;

--- a/src/XIVLauncher.Common.Unix/Compatibility/Wine/WineSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Wine/WineSettings.cs
@@ -42,21 +42,18 @@ public class WineSettings
     {
         this.StartupType = startupType;
 
-        var wineDistroId = CompatUtil.GetWineIdForDistro();
-        switch (managedWine)
+        if (startupType == WineStartupType.Managed)
         {
-            case WineManagedVersion.Stable:
-                this.WineRelease = new WineStableRelease(wineDistroId);
-                break;
-            case WineManagedVersion.Beta:
-                this.WineRelease = new WineBetaRelease(wineDistroId);
-                break;
-            case WineManagedVersion.Legacy:
-                this.WineRelease = new WineLegacyRelease(wineDistroId);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(managedWine.ToString());
+            var wineDistroId = CompatUtil.GetWineIdForDistro();
+            this.WineRelease = managedWine switch
+            {
+                WineManagedVersion.Stable => new WineStableRelease(wineDistroId),
+                WineManagedVersion.Beta => new WineBetaRelease(wineDistroId),
+                WineManagedVersion.Legacy => new WineLegacyRelease(wineDistroId),
+                _ => throw new ArgumentOutOfRangeException(managedWine.ToString())
+            };
         }
+
         this.CustomBinPath = customBinPath;
         this.EsyncOn = esyncOn ? "1" : "0";
         this.FsyncOn = fsyncOn ? "1" : "0";


### PR DESCRIPTION
This does a bit of code cleanup in `CompatUtil` and makes it so that when running on macOS the launcher would not crash with an unhandled exception every time anymore.

Also, it only downloads managed Wine versions when requested by the configuration and not always.

The `WineReleaseDistro.macOS` enum was only added for completeness’ sake; there is currently no real managed Wine that can be downloaded here.