### PR TITLE
Add wine and dxvk info to launcher.log

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -770,7 +770,14 @@ public class MainPage : Page
                 else if (!File.Exists(Path.Combine(App.Settings.WineBinaryPath, "wine64")))
                     throw new InvalidOperationException("Custom wine binary path is invalid: no wine64 found at that location.\n" +
                                                         "Check path carefully for typos: " + App.Settings.WineBinaryPath);
+                
+                Log.Information("Using Custom Wine: " + App.Settings.WineBinaryPath);
             }
+            else
+            {
+                Log.Information("Using Managed Wine: " + App.Settings.WineManagedVersion.ToString());
+            }
+            Log.Information("Using Dxvk Version: " + App.Settings.DxvkVersion.ToString());
 
             var signal = new ManualResetEvent(false);
             var isFailed = false;


### PR DESCRIPTION
This is a very simple patch to add wine and dxvk versions to the launcher.log when trying to launch ffxiv. Should work regardless of dalamud enabled/disabled. This is mostly to aid troubleshooting in the discord.