### PR TITLE
Fix feral gamemode lag

### DIFF
--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -86,6 +86,7 @@ public class SettingsTabWine : SettingsTab
     { 
         get
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return false;
             if (feralGameModeFound != null) return feralGameModeFound ?? false;
             var handle = IntPtr.Zero;
             feralGameModeFound = (NativeLibrary.TryLoad("libgamemodeauto.so.0", out handle));


### PR DESCRIPTION
This makes a single check to see if feral gamemode is installed, and stores that value. This prevents some lag on the WINE tab.