### PR TITLE
refactor: dont autofocus username field on steamdeck

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/LoginFrame.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/LoginFrame.cs
@@ -69,10 +69,7 @@ public class LoginFrame : Component
             this.OnLogin?.Invoke(LoginAction.Game);
         }
 
-        this.loginInput = new Input(Strings.UsernameInput, Strings.UsernameInputHint, new Vector2(12f, 0f), 128)
-        {
-            TakeKeyboardFocus = true
-        };
+        this.loginInput = new Input(Strings.UsernameInput, Strings.UsernameInputHint, new Vector2(12f, 0f), 128);
         this.loginInput.Enter += TriggerLogin;
 
         this.passwordInput = new Input(Strings.PasswordInput, Strings.PasswordInputHint, new Vector2(12f, 0f), 128, flags: ImGuiInputTextFlags.Password | ImGuiInputTextFlags.NoUndoRedo);


### PR DESCRIPTION
This removes the autofocusing of the username field on steamdeck. I don't see why we do this as most of the time it's just an irritation for the user.