### PR TITLE
chore: Update DXVK UI string to 2.7

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/Dxvk/Dxvk.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Dxvk/Dxvk.cs
@@ -13,7 +13,7 @@ namespace XIVLauncher.Common.Unix.Compatibility.Dxvk;
 
 public enum DxvkVersion
 {
-    [SettingsDescription("Stable", "DXVK 2.6 with GPLAsync patches. For most graphics cards.")]
+    [SettingsDescription("Stable", "DXVK 2.7 with GPLAsync patches. For most graphics cards.")]
     Stable,
 
     [SettingsDescription("Legacy", "DXVK 1.10.3 with Async patches. For older graphics cards.")]


### PR DESCRIPTION
DXVK was updated to 2.7 but the string in the UI was kept at 2.6.