### PR TITLE
Add back DXVK 2.6.1 as option

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/Dxvk/Dxvk.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Dxvk/Dxvk.cs
@@ -13,12 +13,14 @@ namespace XIVLauncher.Common.Unix.Compatibility.Dxvk;
 
 public enum DxvkVersion
 {
-    [SettingsDescription("Stable", "DXVK 2.7 with GPLAsync patches. For most graphics cards. AMD/Intel 25.0 or NVK 25.1 or Nvidia 550")]
-    Stable,
-    [SettingsDescription("PreviousStable", "DXVK 2.6.1 with GPLAsync patches. For AMD/Intel 24.0 or Nvidia 535")]
-    PreviousStable,
 
-    [SettingsDescription("Legacy", "DXVK 1.10.3 with Async patches. For older graphics cards.")]
+    [SettingsDescription("Stable", "DXVK 2.6.1 with GPLAsync patches. Requires Mesa 24.0 or Nvidia 535 drivers. Ideal for graphics cards.")]
+    Stable,
+
+    [SettingsDescription("Beta", "DXVK 2.7 with GPLAsync patches. Requires Mesa 25.0 or Nvidia 550 drivers. Ideal for modern graphics cards.")]
+    Beta,
+
+    [SettingsDescription("Legacy", "DXVK 1.10.3 with Async patches. Requires Mesa 22.0 or Nvidia 470 drivers. Ideal for older graphics card.")]
     Legacy,
 
     [SettingsDescription("Disabled", "Use OpenGL/WineD3D instead. Slow, and might not work with Dalamud.")]
@@ -48,7 +50,7 @@ public static class Dxvk
         IDxvkRelease release = version switch
         {
             DxvkVersion.Stable => new DxvkStableRelease(),
-            DxvkVersion.PreviousStable => new DxvkPreviousStableRelease(),
+            DxvkVersion.Beta => new DxvkBetaRelease(),
             DxvkVersion.Legacy => new DxvkLegacyRelease(),
             _ => throw new NotImplementedException(),
         };

--- a/src/XIVLauncher.Common.Unix/Compatibility/Dxvk/Releases/DxvkBeta.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Dxvk/Releases/DxvkBeta.cs
@@ -1,0 +1,8 @@
+namespace XIVLauncher.Common.Unix.Compatibility.Dxvk.Releases;
+
+public sealed class DxvkBetaRelease : IDxvkRelease
+{
+    public string Name { get; } = "dxvk-gplasync-v2.7-1";
+    public string DownloadUrl { get; } = "https://raw.githubusercontent.com/goatcorp/xlcore-distrib/refs/heads/main/dxvk-gplasync-v2.7-1.tar.gz";
+    public string Checksum { get; } = "1fe59a91f3d3a09a132d1f9c3f7e94d47154e53e58f935daa090aa6dea5c8e6c64800334a6f3014751492a2f32002d8ce63e8086284df0b8d4cbace0353e0f3b";
+}

--- a/src/XIVLauncher.Common.Unix/Compatibility/Dxvk/Releases/DxvkPreviousStable.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Dxvk/Releases/DxvkPreviousStable.cs
@@ -1,8 +1,0 @@
-namespace XIVLauncher.Common.Unix.Compatibility.Dxvk.Releases;
-
-public sealed class DxvkPreviousStableRelease : IDxvkRelease
-{
-    public string Name { get; } = "dxvk-gplasync-v2.6.1-1";
-    public string DownloadUrl { get; } = "https://raw.githubusercontent.com/goatcorp/xlcore-distrib/refs/heads/main/dxvk-gplasync-v2.6.1-1.tar.gz";
-    public string Checksum { get; } = "4196972aa26ffd7da94542fef065bdb2a4a0926498fe4834ef75f43dd2a8c393db8b0edffa21a2906f664a99679cfea4c371c5a9577eb025410b76d63df8a872";
-}

--- a/src/XIVLauncher.Common.Unix/Compatibility/Dxvk/Releases/DxvkStable.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Dxvk/Releases/DxvkStable.cs
@@ -2,7 +2,7 @@ namespace XIVLauncher.Common.Unix.Compatibility.Dxvk.Releases;
 
 public sealed class DxvkStableRelease : IDxvkRelease
 {
-    public string Name { get; } = "dxvk-gplasync-v2.7-1";
-    public string DownloadUrl { get; } = "https://raw.githubusercontent.com/goatcorp/xlcore-distrib/refs/heads/main/dxvk-gplasync-v2.7-1.tar.gz";
-    public string Checksum { get; } = "1fe59a91f3d3a09a132d1f9c3f7e94d47154e53e58f935daa090aa6dea5c8e6c64800334a6f3014751492a2f32002d8ce63e8086284df0b8d4cbace0353e0f3b";
+    public string Name { get; } = "dxvk-gplasync-v2.6.1-1";
+    public string DownloadUrl { get; } = "https://raw.githubusercontent.com/goatcorp/xlcore-distrib/refs/heads/main/dxvk-gplasync-v2.6.1-1.tar.gz";
+    public string Checksum { get; } = "4196972aa26ffd7da94542fef065bdb2a4a0926498fe4834ef75f43dd2a8c393db8b0edffa21a2906f664a99679cfea4c371c5a9577eb025410b76d63df8a872";
 }

--- a/src/XIVLauncher.Common.Unix/Compatibility/Wine/WineSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Wine/WineSettings.cs
@@ -16,13 +16,13 @@ public enum WineStartupType
 
 public enum WineManagedVersion
 {
-    [SettingsDescription("Stable", "Based on WINE 10.8 - recommended for most users.")]
+    [SettingsDescription("Stable", "The most stable experience, based on WINE 10.8 - recommended for most users.")]
     Stable,
 
-    [SettingsDescription("Beta", "Testing ground for the newest wine changes. Based on WINE 10.8 with lsteamclient patches.")]
+    [SettingsDescription("Beta", "Testing ground for the newest wine changes, based on WINE 10.8 with lsteamclient patches.")]
     Beta,
 
-    [SettingsDescription("Legacy", "Based on WINE 8.5 - use for compatibility with some plugins.")]
+    [SettingsDescription("Legacy", "For older systems or compatibility, based on WINE 8.5.")]
     Legacy,
 }
 


### PR DESCRIPTION
Since DXVK increased its driver version requirements in DXVK 2.7, some formerly working GPUs aren't able to use it anymore.

This adds a "previous stable" entry into the list for users who have something newer than legacy, but not quite able to get the latest driver in a stable manner. (Ex: MX250 cards or LTS distros)
