### PR TITLE
fix: add library paths and sdl2 to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,16 @@
         devShells.default = pkgs.mkShell {
           packages = with pkgs; [
             dotnet-sdk_9
+            SDL2
           ];
+
+          env = {
+            LD_LIBRARY_PATH = "${
+              pkgs.lib.makeLibraryPath [
+                pkgs.SDL2
+              ]
+            }:$LD_LIBRARY_PATH";
+          };
         };
       }
     );


### PR DESCRIPTION
needed for actually letting the dev shell run properly with all dependencies when developing for `src/XIVLauncher.Core`.