### PR TITLE
refactor: various compat cleanup

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatUtil.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatUtil.cs
@@ -23,7 +23,7 @@ public static class CompatUtil
         {
             return WineReleaseDistro.macOS;
         }
-        
+
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
             throw new InvalidOperationException("GetWineIdForDistro called on unsupported platform");

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
@@ -26,7 +26,7 @@ public class CompatibilityTools
     private readonly StreamWriter logWriter;
 
     private string WineBinPath => Settings.StartupType == WineStartupType.Managed ?
-                                    Path.Combine(wineDirectory.FullName, Settings.WineRelease.Name, "bin") :
+                                    Path.Combine(wineDirectory.FullName, Settings.Release.Name, "bin") :
                                     Settings.CustomBinPath;
     private string Wine64Path => Path.Combine(WineBinPath, "wine64");
     private string WineServerPath => Path.Combine(WineBinPath, "wineserver");
@@ -82,7 +82,7 @@ public class CompatibilityTools
     {
         if (!File.Exists(Wine64Path))
         {
-            Log.Information($"Compatibility tool does not exist, downloading {Settings.WineRelease.DownloadUrl}");
+            Log.Information($"Compatibility tool does not exist, downloading {Settings.Release.DownloadUrl}");
             await DownloadTool(tempPath).ConfigureAwait(false);
         }
 
@@ -96,8 +96,8 @@ public class CompatibilityTools
     {
         using var client = new HttpClient();
         var tempFilePath = Path.Combine(tempPath.FullName, $"{Guid.NewGuid()}");
-        await File.WriteAllBytesAsync(tempFilePath, await client.GetByteArrayAsync(Settings.WineRelease.DownloadUrl).ConfigureAwait(false)).ConfigureAwait(false);
-        if (!CompatUtil.EnsureChecksumMatch(tempFilePath, Settings.WineRelease.Checksums))
+        await File.WriteAllBytesAsync(tempFilePath, await client.GetByteArrayAsync(Settings.Release.DownloadUrl).ConfigureAwait(false)).ConfigureAwait(false);
+        if (!CompatUtil.EnsureChecksumMatch(tempFilePath, Settings.Release.Checksums))
         {
             throw new InvalidDataException("SHA512 checksum verification failed");
         }
@@ -182,9 +182,15 @@ public class CompatibilityTools
 
         wineEnviromentVariables.Add("DXVK_HUD", dxvkHud);
         wineEnviromentVariables.Add("DXVK_ASYNC", dxvkAsyncOn);
-        wineEnviromentVariables.Add("WINEESYNC", Settings.EsyncOn);
-        wineEnviromentVariables.Add("WINEFSYNC", Settings.FsyncOn);
-
+        switch (Settings.SyncType)
+        {
+            case WineSyncType.ESync:
+                wineEnviromentVariables.Add("WINEESYNC", "1");
+                break;
+            case WineSyncType.FSync:
+                wineEnviromentVariables.Add("WINEFSYNC", "1");
+                break;
+        }
         wineEnviromentVariables.Add("LD_PRELOAD", ldPreload);
 
         MergeDictionaries(psi.EnvironmentVariables, wineEnviromentVariables);

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -82,7 +82,7 @@ public class CompatibilityTools
     {
         if (!File.Exists(Wine64Path))
         {
-            Log.Information($"Compatibility tool does not exist, downloading {Settings.WineRelease.DownloadUrl}");
+            Log.Information($"Compatibility tool does not exist, downloading {Settings.Release.DownloadUrl}");
             await DownloadTool(httpClient, tempPath).ConfigureAwait(false);
         }
 
@@ -95,8 +95,8 @@ public class CompatibilityTools
     private async Task DownloadTool(HttpClient httpClient, DirectoryInfo tempPath)
     {
         var tempFilePath = Path.Combine(tempPath.FullName, $"{Guid.NewGuid()}");
-        await File.WriteAllBytesAsync(tempFilePath, await httpClient.GetByteArrayAsync(Settings.WineRelease.DownloadUrl).ConfigureAwait(false)).ConfigureAwait(false);
-        if (!CompatUtil.EnsureChecksumMatch(tempFilePath, Settings.WineRelease.Checksums))
+        await File.WriteAllBytesAsync(tempFilePath, await httpClient.GetByteArrayAsync(Settings.Release.DownloadUrl).ConfigureAwait(false)).ConfigureAwait(false);
+        if (!CompatUtil.EnsureChecksumMatch(tempFilePath, Settings.Release.Checksums))
         {
             throw new InvalidDataException("SHA512 checksum verification failed");
         }

--- a/src/XIVLauncher.Common.Unix/Compatibility/Wine/Releases/IWineRelease.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Wine/Releases/IWineRelease.cs
@@ -1,4 +1,4 @@
-namespace XIVLauncher.Common.Unix.Compatibility.Wine;
+namespace XIVLauncher.Common.Unix.Compatibility.Wine.Releases;
 
 public interface IWineRelease
 {

--- a/src/XIVLauncher.Common.Unix/Compatibility/Wine/WineUtility.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Wine/WineUtility.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace XIVLauncher.Common.Unix.Compatibility.Wine;
+
+public enum FsyncSupport
+{
+    Supported,
+    UnsupportedPlatform,
+    OutdatedKernel,
+}
+
+public static class WineUtility
+{
+    public static FsyncSupport SystemFsyncSupport()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return FsyncSupport.UnsupportedPlatform;
+        if (Environment.OSVersion.Version.Major < 5 && (Environment.OSVersion.Version.Minor < 16 || Environment.OSVersion.Version.Major < 6))
+            return FsyncSupport.OutdatedKernel;
+        return FsyncSupport.Supported;
+    }
+}

--- a/src/XIVLauncher.Common.Unix/UnixDalamudCompatibilityCheck.cs
+++ b/src/XIVLauncher.Common.Unix/UnixDalamudCompatibilityCheck.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+
 using XIVLauncher.Common.PlatformAbstractions;
 
 namespace XIVLauncher.Common.Unix;

--- a/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
@@ -1,11 +1,14 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Newtonsoft.Json;
+
 using Serilog;
+
 using XIVLauncher.Common.Dalamud;
 using XIVLauncher.Common.PlatformAbstractions;
 using XIVLauncher.Common.Unix.Compatibility;

--- a/src/XIVLauncher.Common.Unix/UnixGameRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixGameRunner.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/src/XIVLauncher.Common.Unix/UnixSteam.cs
+++ b/src/XIVLauncher.Common.Unix/UnixSteam.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Threading.Tasks;
+
 using Steamworks;
+
 using XIVLauncher.Common.PlatformAbstractions;
 
 namespace XIVLauncher.Common.Unix

--- a/src/XIVLauncher.Core/Accounts/AccountManager.cs
+++ b/src/XIVLauncher.Core/Accounts/AccountManager.cs
@@ -1,8 +1,8 @@
+using System.Collections.ObjectModel;
+
 using Newtonsoft.Json;
 
 using Serilog;
-
-using System.Collections.ObjectModel;
 
 namespace XIVLauncher.Core.Accounts;
 

--- a/src/XIVLauncher.Core/AppUtil.cs
+++ b/src/XIVLauncher.Core/AppUtil.cs
@@ -15,7 +15,7 @@ public static partial class AppUtil
             throw new ArgumentException($"Resource {resourceName} not found", nameof(resourceName));
 
         var ret = new byte[s.Length];
-        s.Read(ret, 0, (int)s.Length);
+        s.ReadExactly(ret, 0, (int)s.Length);
         return ret;
     }
 

--- a/src/XIVLauncher.Core/Components/Background.cs
+++ b/src/XIVLauncher.Core/Components/Background.cs
@@ -1,6 +1,6 @@
-using Hexa.NET.ImGui;
-
 using System.Numerics;
+
+using Hexa.NET.ImGui;
 
 namespace XIVLauncher.Core.Components;
 

--- a/src/XIVLauncher.Core/Components/Common/Button.cs
+++ b/src/XIVLauncher.Core/Components/Common/Button.cs
@@ -1,6 +1,6 @@
-using Hexa.NET.ImGui;
-
 using System.Numerics;
+
+using Hexa.NET.ImGui;
 
 namespace XIVLauncher.Core.Components.Common;
 

--- a/src/XIVLauncher.Core/Components/Common/Checkbox.cs
+++ b/src/XIVLauncher.Core/Components/Common/Checkbox.cs
@@ -1,6 +1,6 @@
-using Hexa.NET.ImGui;
-
 using System.Numerics;
+
+using Hexa.NET.ImGui;
 
 namespace XIVLauncher.Core.Components.Common;
 

--- a/src/XIVLauncher.Core/Components/Common/Input.cs
+++ b/src/XIVLauncher.Core/Components/Common/Input.cs
@@ -1,8 +1,8 @@
+using System.Numerics;
+
 using Hexa.NET.ImGui;
 
 using Serilog;
-
-using System.Numerics;
 
 namespace XIVLauncher.Core.Components.Common;
 
@@ -92,7 +92,7 @@ public class Input : Component
             ImGui.BeginDisabled();
             isDisabled = true;
         }
-            
+
 
         var ww = ImGui.GetWindowWidth();
         ImGui.SetNextItemWidth(ww);

--- a/src/XIVLauncher.Core/Components/FtsPage.cs
+++ b/src/XIVLauncher.Core/Components/FtsPage.cs
@@ -1,6 +1,6 @@
-using Hexa.NET.ImGui;
-
 using System.Numerics;
+
+using Hexa.NET.ImGui;
 
 namespace XIVLauncher.Core.Components;
 

--- a/src/XIVLauncher.Core/Components/LoadingPage/LoadingPage.cs
+++ b/src/XIVLauncher.Core/Components/LoadingPage/LoadingPage.cs
@@ -1,6 +1,6 @@
-using Hexa.NET.ImGui;
-
 using System.Numerics;
+
+using Hexa.NET.ImGui;
 
 using XIVLauncher.Core.Components.Common;
 using XIVLauncher.Core.Resources.Localization;

--- a/src/XIVLauncher.Core/Components/LoadingPage/Spinner.cs
+++ b/src/XIVLauncher.Core/Components/LoadingPage/Spinner.cs
@@ -1,6 +1,6 @@
-using Hexa.NET.ImGui;
-
 using System.Numerics;
+
+using Hexa.NET.ImGui;
 
 namespace XIVLauncher.Core.Components.LoadingPage;
 

--- a/src/XIVLauncher.Core/Components/MainPage/AccountSwitcher.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/AccountSwitcher.cs
@@ -1,6 +1,6 @@
-using Hexa.NET.ImGui;
-
 using System.Numerics;
+
+using Hexa.NET.ImGui;
 
 using XIVLauncher.Core.Accounts;
 using XIVLauncher.Core.Resources.Localization;

--- a/src/XIVLauncher.Core/Components/MainPage/ActionButtons.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/ActionButtons.cs
@@ -1,6 +1,6 @@
-using Hexa.NET.ImGui;
-
 using System.Numerics;
+
+using Hexa.NET.ImGui;
 
 using XIVLauncher.Core.Resources.Localization;
 

--- a/src/XIVLauncher.Core/Components/MainPage/LoginFrame.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/LoginFrame.cs
@@ -1,6 +1,6 @@
-using Hexa.NET.ImGui;
-
 using System.Numerics;
+
+using Hexa.NET.ImGui;
 
 using XIVLauncher.Core.Accounts.Secrets.Providers;
 using XIVLauncher.Core.Components.Common;

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -1,10 +1,10 @@
+using System.Diagnostics;
+using System.Numerics;
+
 using Hexa.NET.ImGui;
 using Hexa.NET.SDL3;
 
 using Serilog;
-
-using System.Diagnostics;
-using System.Numerics;
 
 using XIVLauncher.Common;
 using XIVLauncher.Common.Addon;
@@ -706,10 +706,7 @@ public class MainPage : Page
             var _ = Task.Run(async () =>
             {
                 var tempPath = App.Storage.GetFolder("temp");
-                var winver = (App.Settings.SetWin7 ?? true) ? "win7" : "win10";
-
                 await Program.CompatibilityTools.EnsureTool(tempPath).ConfigureAwait(false);
-                Program.CompatibilityTools.RunInPrefix($"winecfg /v {winver}");
             }).ContinueWith(t =>
             {
                 isFailed = t.IsFaulted || t.IsCanceled;

--- a/src/XIVLauncher.Core/Components/MainPage/NewsFrame.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/NewsFrame.cs
@@ -1,6 +1,6 @@
-using Hexa.NET.ImGui;
-
 using System.Numerics;
+
+using Hexa.NET.ImGui;
 
 using XIVLauncher.Common;
 using XIVLauncher.Common.Game;

--- a/src/XIVLauncher.Core/Components/OtpEntryPage.cs
+++ b/src/XIVLauncher.Core/Components/OtpEntryPage.cs
@@ -1,8 +1,8 @@
+using System.Numerics;
+
 using Hexa.NET.ImGui;
 
 using Serilog;
-
-using System.Numerics;
 
 using XIVLauncher.Common.Http;
 using XIVLauncher.Core.Resources.Localization;

--- a/src/XIVLauncher.Core/Components/SettingsPage/SettingsPage.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/SettingsPage.cs
@@ -1,7 +1,7 @@
-using Hexa.NET.ImGui;
-
 using System.Collections.Immutable;
 using System.Numerics;
+
+using Hexa.NET.ImGui;
 
 using XIVLauncher.Core.Components.SettingsPage.Tabs;
 using XIVLauncher.Core.Resources.Localization;

--- a/src/XIVLauncher.Core/Components/SettingsPage/SettingsTab.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/SettingsTab.cs
@@ -1,6 +1,6 @@
-using Hexa.NET.ImGui;
-
 using System.Numerics;
+
+using Hexa.NET.ImGui;
 
 namespace XIVLauncher.Core.Components.SettingsPage;
 

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabAbout.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabAbout.cs
@@ -1,6 +1,6 @@
-using Hexa.NET.ImGui;
-
 using System.Numerics;
+
+using Hexa.NET.ImGui;
 
 using XIVLauncher.Common.Util;
 using XIVLauncher.Core.Resources.Localization;

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDebug.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabDebug.cs
@@ -1,6 +1,6 @@
-using Hexa.NET.ImGui;
-
 using System.Collections;
+
+using Hexa.NET.ImGui;
 
 using XIVLauncher.Core.Resources.Localization;
 

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -1,7 +1,7 @@
-using Hexa.NET.ImGui;
-
 using System.Numerics;
 using System.Runtime.InteropServices;
+
+using Hexa.NET.ImGui;
 
 using XIVLauncher.Common.Unix.Compatibility.Dxvk;
 using XIVLauncher.Common.Unix.Compatibility.Wine;
@@ -20,29 +20,47 @@ public class SettingsTabWine : SettingsTab
     {
         Entries = new SettingsEntry[]
         {
+            // WINE
             startupTypeSetting = new SettingsEntry<WineStartupType>(Strings.WineInstallSetting, Strings.WineInstallSettingDescription,
                 () => Program.Config.WineStartupType ?? WineStartupType.Managed, x => Program.Config.WineStartupType = x),
-
             new SettingsEntry<WineManagedVersion>(Strings.WineVersionSetting, Strings.WineVersionSettingDescription, () => Program.Config.WineManagedVersion ?? WineManagedVersion.Stable,
                 x => Program.Config.WineManagedVersion = x )
             {
                 CheckVisibility = () => startupTypeSetting.Value == WineStartupType.Managed
             },
-
             new SettingsEntry<string>(Strings.WineBinaryPathSetting,
                 Strings.WineBinarySettingDescription,
                 () => Program.Config.WineBinaryPath, s => Program.Config.WineBinaryPath = s)
             {
                 CheckVisibility = () => startupTypeSetting.Value == WineStartupType.Custom
             },
+            new SettingsEntry<WineSyncType>("WINE Sync Method", "How Wine synchronizes multi-threaded operations.", () => Program.Config.WineSyncType ?? WineSyncType.FSync, x => Program.Config.WineSyncType = x)
+            {
+                CheckValidity = b =>
+                {
+                    switch (WineUtility.SystemFsyncSupport())
+                    {
+                        case FsyncSupport.UnsupportedPlatform:
+                            return "FSync is only available on Linux";
+                        case FsyncSupport.OutdatedKernel:
+                            return Strings.EnableFSyncSettingMinKernelValidation;
+                        case FsyncSupport.Supported:
+                        default:
+                            return null;
+                    }
+                }
+            },
+            new SettingsEntry<string>(Strings.WineDebugAdditionalVarSetting, Strings.WineDebugAdditionalVarSettingDescription, () => Program.Config.WineDebugVars ?? string.Empty, s => Program.Config.WineDebugVars = s),
 
+            // DXVK
             dxvkVersionSetting = new SettingsEntry<DxvkVersion>(Strings.DXVKVersionSetting, Strings.DXVKVersionSettingDescription, () => Program.Config.DxvkVersion ?? DxvkVersion.Stable, x => Program.Config.DxvkVersion = x),
-
+            new SettingsEntry<DxvkHudType>(Strings.EnableDXVKOverlaySetting, Strings.EnableDXVKOverlaySettingDescription, () => Program.Config.DxvkHudType, type => Program.Config.DxvkHudType = type),
             new SettingsEntry<bool>(Strings.DXVKEnableAsyncSetting, Strings.DXVKEnableAsyncSettingDescription, () => Program.Config.DxvkAsyncEnabled ?? true, b => Program.Config.DxvkAsyncEnabled = b)
             {
                 CheckVisibility = () => dxvkVersionSetting.Value != DxvkVersion.Disabled
             },
 
+            // GameMode
             new SettingsEntry<bool>(Strings.EnableFeralGameModeSetting, Strings.EnableFeralGameModeSettingDescription, () => Program.Config.GameModeEnabled ?? true, b => Program.Config.GameModeEnabled = b)
             {
                 CheckVisibility = () => RuntimeInformation.IsOSPlatform(OSPlatform.Linux),
@@ -53,24 +71,6 @@ public class SettingsTabWine : SettingsTab
                     return null;
                 }
             },
-
-            new SettingsEntry<bool>(Strings.EnableESyncSetting, Strings.EnableESyncSettingDescription, () => Program.Config.ESyncEnabled ?? true, b => Program.Config.ESyncEnabled = b),
-            new SettingsEntry<bool>(Strings.EnableFSyncSetting, Strings.EnableFSyncSettingDescription, () => Program.Config.FSyncEnabled ?? true, b => Program.Config.FSyncEnabled = b)
-            {
-                CheckVisibility = () => RuntimeInformation.IsOSPlatform(OSPlatform.Linux),
-                CheckValidity = b =>
-                {
-                    if (b == true && (Environment.OSVersion.Version.Major < 5 && (Environment.OSVersion.Version.Minor < 16 || Environment.OSVersion.Version.Major < 6)))
-                        return Strings.EnableFSyncSettingMinKernelValidation;
-
-                    return null;
-                }
-            },
-
-            new SettingsEntry<bool>(Strings.SetWindows7Setting, Strings.SetWindows7SettingDescription, () => Program.Config.SetWin7 ?? true, b => Program.Config.SetWin7 = b),
-
-            new SettingsEntry<DxvkHudType>(Strings.EnableDXVKOverlaySetting, Strings.EnableDXVKOverlaySettingDescription, () => Program.Config.DxvkHudType, type => Program.Config.DxvkHudType = type),
-            new SettingsEntry<string>(Strings.WineDebugAdditionalVarSetting, Strings.WineDebugAdditionalVarSettingDescription, () => Program.Config.WineDebugVars ?? string.Empty, s => Program.Config.WineDebugVars = s)
         };
     }
 

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -34,14 +34,14 @@ public class SettingsTabWine : SettingsTab
             {
                 CheckVisibility = () => startupTypeSetting.Value == WineStartupType.Custom
             },
-            new SettingsEntry<WineSyncType>("WINE Sync Method", "How Wine synchronizes multi-threaded operations.", () => Program.Config.WineSyncType ?? WineSyncType.FSync, x => Program.Config.WineSyncType = x)
+            new SettingsEntry<WineSyncType>(Strings.WineSyncMethodSetting, Strings.WineSyncMethodSettingDescription, () => Program.Config.WineSyncType ?? WineSyncType.FSync, x => Program.Config.WineSyncType = x)
             {
                 CheckValidity = b =>
                 {
                     switch (WineUtility.SystemFsyncSupport())
                     {
                         case FsyncSupport.UnsupportedPlatform:
-                            return "FSync is only available on Linux";
+                            return Strings.EnableFsyncSettingUnsupportedPlatformValidation;
                         case FsyncSupport.OutdatedKernel:
                             return Strings.EnableFSyncSettingMinKernelValidation;
                         case FsyncSupport.Supported:

--- a/src/XIVLauncher.Core/Components/SteamDeckPromptPage.cs
+++ b/src/XIVLauncher.Core/Components/SteamDeckPromptPage.cs
@@ -1,6 +1,6 @@
-using Hexa.NET.ImGui;
-
 using System.Numerics;
+
+using Hexa.NET.ImGui;
 
 namespace XIVLauncher.Core.Components;
 

--- a/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
+++ b/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
@@ -55,9 +55,8 @@ public interface ILauncherConfig
     #region Linux
 
     public WineStartupType? WineStartupType { get; set; }
-
     public WineManagedVersion? WineManagedVersion { get; set; }
-
+    public WineSyncType? WineSyncType { get; set; }
     public string? WineBinaryPath { get; set; }
 
     public bool? GameModeEnabled { get; set; }
@@ -65,10 +64,6 @@ public interface ILauncherConfig
     public DxvkVersion? DxvkVersion { get; set; }
 
     public bool? DxvkAsyncEnabled { get; set; }
-
-    public bool? ESyncEnabled { get; set; }
-
-    public bool? FSyncEnabled { get; set; }
 
     public DxvkHudType DxvkHudType { get; set; }
 
@@ -81,8 +76,6 @@ public interface ILauncherConfig
     public bool? FixIM { get; set; }
 
     public bool? FixError127 { get; set; }
-
-    public bool? SetWin7 { get; set; }
 
     public bool? DontUseSystemTz { get; set; }
 

--- a/src/XIVLauncher.Core/FontManager.cs
+++ b/src/XIVLauncher.Core/FontManager.cs
@@ -1,6 +1,6 @@
-using Hexa.NET.ImGui;
-
 using System.Runtime.InteropServices;
+
+using Hexa.NET.ImGui;
 
 namespace XIVLauncher.Core;
 

--- a/src/XIVLauncher.Core/ImGuiBindings.cs
+++ b/src/XIVLauncher.Core/ImGuiBindings.cs
@@ -1,12 +1,12 @@
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.InteropServices;
+
 using Hexa.NET.ImGui;
 using Hexa.NET.ImGui.Backends.SDL3;
 using Hexa.NET.SDL3;
 
 using HexaGen.Runtime;
-
-using System.Diagnostics;
-using System.Numerics;
-using System.Runtime.InteropServices;
 
 using ImSDLEvent = Hexa.NET.ImGui.Backends.SDL3.SDLEvent;
 using ImSDLGPUCommandBuffer = Hexa.NET.ImGui.Backends.SDL3.SDLGPUCommandBuffer;

--- a/src/XIVLauncher.Core/ImGuiHelpers.cs
+++ b/src/XIVLauncher.Core/ImGuiHelpers.cs
@@ -1,6 +1,6 @@
-using Hexa.NET.ImGui;
-
 using System.Numerics;
+
+using Hexa.NET.ImGui;
 
 namespace XIVLauncher.Core;
 

--- a/src/XIVLauncher.Core/LauncherApp.cs
+++ b/src/XIVLauncher.Core/LauncherApp.cs
@@ -1,9 +1,9 @@
+using System.Diagnostics;
+using System.Numerics;
+
 using Hexa.NET.ImGui;
 
 using Serilog;
-
-using System.Diagnostics;
-using System.Numerics;
 
 using XIVLauncher.Common;
 using XIVLauncher.Common.Game;

--- a/src/XIVLauncher.Core/LauncherClientConfig.cs
+++ b/src/XIVLauncher.Core/LauncherClientConfig.cs
@@ -1,7 +1,7 @@
 
-using Serilog;
-
 using System.Net.Http.Json;
+
+using Serilog;
 
 namespace XIVLauncher.Core;
 

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -1,11 +1,12 @@
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
 using Config.Net;
 
 using Hexa.NET.SDL3;
 
 using Serilog;
-
-using System.Numerics;
-using System.Runtime.InteropServices;
 
 using XIVLauncher.Common;
 using XIVLauncher.Common.Dalamud;
@@ -119,12 +120,10 @@ sealed class Program
         Config.GameModeEnabled ??= false;
         Config.DxvkVersion ??= DxvkVersion.Stable;
         Config.DxvkAsyncEnabled ??= true;
-        Config.ESyncEnabled ??= true;
-        Config.FSyncEnabled ??= false;
-        Config.SetWin7 ??= true;
 
         Config.WineStartupType ??= WineStartupType.Managed;
         Config.WineManagedVersion ??= WineManagedVersion.Stable;
+        Config.WineSyncType ??= WineUtility.SystemFsyncSupport() == FsyncSupport.Supported ? WineSyncType.FSync : WineSyncType.ESync;
         Config.WineBinaryPath ??= "/usr/bin";
         Config.WineDebugVars ??= "-all";
 
@@ -350,7 +349,7 @@ sealed class Program
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
         var wineLogFile = new FileInfo(Path.Combine(storage.GetFolder("logs").FullName, "wine.log"));
         var winePrefix = storage.GetFolder("wineprefix");
-        var wineSettings = new WineSettings(Config.WineStartupType ?? WineStartupType.Custom, Config.WineManagedVersion ?? WineManagedVersion.Stable, Config.WineBinaryPath, Config.WineDebugVars, wineLogFile, winePrefix, Config.ESyncEnabled ?? true, Config.FSyncEnabled ?? false);
+        var wineSettings = new WineSettings(Config.WineStartupType ?? WineStartupType.Custom, Config.WineManagedVersion ?? WineManagedVersion.Stable, Config.WineBinaryPath, Config.WineDebugVars, wineLogFile, winePrefix, Config.WineSyncType ?? WineSyncType.FSync);
         var toolsFolder = storage.GetFolder("compatibilitytool");
         Directory.CreateDirectory(Path.Combine(toolsFolder.FullName, "dxvk"));
         Directory.CreateDirectory(Path.Combine(toolsFolder.FullName, "wine"));

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.Designer.cs
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.Designer.cs
@@ -164,46 +164,10 @@ namespace XIVLauncher.Core.Resources.Localization {
                 return ResourceManager.GetString("EnableFeralGameModeNotFoundValidation", resourceCulture);
             }
         }
-        
-        internal static string EnableESyncSetting {
-            get {
-                return ResourceManager.GetString("EnableESyncSetting", resourceCulture);
-            }
-        }
-        
-        internal static string EnableFSyncSetting {
-            get {
-                return ResourceManager.GetString("EnableFSyncSetting", resourceCulture);
-            }
-        }
-        
-        internal static string EnableESyncSettingDescription {
-            get {
-                return ResourceManager.GetString("EnableESyncSettingDescription", resourceCulture);
-            }
-        }
-        
-        internal static string EnableFSyncSettingDescription {
-            get {
-                return ResourceManager.GetString("EnableFSyncSettingDescription", resourceCulture);
-            }
-        }
-        
+
         internal static string EnableFSyncSettingMinKernelValidation {
             get {
                 return ResourceManager.GetString("EnableFSyncSettingMinKernelValidation", resourceCulture);
-            }
-        }
-        
-        internal static string SetWindows7Setting {
-            get {
-                return ResourceManager.GetString("SetWindows7Setting", resourceCulture);
-            }
-        }
-        
-        internal static string SetWindows7SettingDescription {
-            get {
-                return ResourceManager.GetString("SetWindows7SettingDescription", resourceCulture);
             }
         }
         

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.Designer.cs
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.Designer.cs
@@ -164,7 +164,7 @@ namespace XIVLauncher.Core.Resources.Localization {
                 return ResourceManager.GetString("EnableFeralGameModeNotFoundValidation", resourceCulture);
             }
         }
-
+        
         internal static string EnableFSyncSettingMinKernelValidation {
             get {
                 return ResourceManager.GetString("EnableFSyncSettingMinKernelValidation", resourceCulture);
@@ -1044,6 +1044,24 @@ namespace XIVLauncher.Core.Resources.Localization {
         internal static string RepairFailureError {
             get {
                 return ResourceManager.GetString("RepairFailureError", resourceCulture);
+            }
+        }
+        
+        internal static string WineSyncMethodSetting {
+            get {
+                return ResourceManager.GetString("WineSyncMethodSetting", resourceCulture);
+            }
+        }
+        
+        internal static string WineSyncMethodSettingDescription {
+            get {
+                return ResourceManager.GetString("WineSyncMethodSettingDescription", resourceCulture);
+            }
+        }
+        
+        internal static string EnableFsyncSettingUnsupportedPlatformValidation {
+            get {
+                return ResourceManager.GetString("EnableFsyncSettingUnsupportedPlatformValidation", resourceCulture);
             }
         }
     }

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.resx
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.resx
@@ -82,26 +82,8 @@ It should be an absolute path to a folder containing wine64 and wineserver binar
     <data name="EnableFeralGameModeNotFoundValidation" xml:space="preserve">
         <value>GameMode was not detected on your system.</value>
     </data>
-    <data name="EnableESyncSetting" xml:space="preserve">
-        <value>Enable ESync</value>
-    </data>
-    <data name="EnableFSyncSetting" xml:space="preserve">
-        <value>Enable FSync</value>
-    </data>
-    <data name="EnableESyncSettingDescription" xml:space="preserve">
-        <value>Enable eventfd-based synchronization.</value>
-    </data>
-    <data name="EnableFSyncSettingDescription" xml:space="preserve">
-        <value>Enable fast user mutex (futex2).</value>
-    </data>
     <data name="EnableFSyncSettingMinKernelValidation" xml:space="preserve">
         <value>Linux kernel 5.16 or higher is required for FSync.</value>
-    </data>
-    <data name="SetWindows7Setting" xml:space="preserve">
-        <value>Set Windows version to 7</value>
-    </data>
-    <data name="SetWindows7SettingDescription" xml:space="preserve">
-        <value>Default for WINE 8.1+ is Windows 10, but this causes issues with some Dalamud plugins. Windows 7 is recommended for now.</value>
     </data>
     <data name="EnableDXVKOverlaySetting" xml:space="preserve">
         <value>DXVK Overlay</value>

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.resx
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.resx
@@ -564,4 +564,13 @@ Please try again later.</value>
         <value>An error occurred while repairing the game files.
 You may have to reinstall the game.</value>
     </data>
+    <data name="WineSyncMethodSetting" xml:space="preserve">
+        <value>WINE Sync Method</value>
+    </data>
+    <data name="WineSyncMethodSettingDescription" xml:space="preserve">
+        <value>How Wine synchronizes multi-threaded operations.</value>
+    </data>
+    <data name="EnableFsyncSettingUnsupportedPlatformValidation" xml:space="preserve">
+        <value>FSync is only available on Linux</value>
+    </data>
 </root>

--- a/src/XIVLauncher.Core/Style/StyleHandle.cs
+++ b/src/XIVLauncher.Core/Style/StyleHandle.cs
@@ -1,6 +1,6 @@
-using Hexa.NET.ImGui;
-
 using System.Numerics;
+
+using Hexa.NET.ImGui;
 
 namespace XIVLauncher.Core.Style;
 

--- a/src/XIVLauncher.Core/Style/StyleModelV1.cs
+++ b/src/XIVLauncher.Core/Style/StyleModelV1.cs
@@ -1,8 +1,8 @@
+using System.Numerics;
+
 using Hexa.NET.ImGui;
 
 using Newtonsoft.Json;
-
-using System.Numerics;
 
 namespace XIVLauncher.Core.Style;
 

--- a/src/XIVLauncher.Core/Support/Troubleshooting.cs
+++ b/src/XIVLauncher.Core/Support/Troubleshooting.cs
@@ -1,8 +1,8 @@
+using System.Text;
+
 using Newtonsoft.Json;
 
 using Serilog;
-
-using System.Text;
 
 using XIVLauncher.Common;
 using XIVLauncher.Common.Dalamud;

--- a/src/XIVLauncher.Core/TextureWrap.cs
+++ b/src/XIVLauncher.Core/TextureWrap.cs
@@ -1,9 +1,9 @@
+using System.Numerics;
+using System.Runtime.InteropServices;
+
 using Hexa.NET.ImGui;
 using Hexa.NET.SDL3;
 using Hexa.NET.SDL3.Image;
-
-using System.Numerics;
-using System.Runtime.InteropServices;
 
 namespace XIVLauncher.Core;
 


### PR DESCRIPTION
Make fsync the Linux default on supported kernels, tidy sync ui to only allow 1 selection, cleanup some parts of compat handling, removes the windows 7 override as it's not really useful anymore.

Also runs dotnet format