### PR TITLE
chore: cleanup nullability warnings

### DIFF
--- a/src/XIVLauncher.Core/Accounts/AccountManager.cs
+++ b/src/XIVLauncher.Core/Accounts/AccountManager.cs
@@ -92,11 +92,16 @@ public class AccountManager
             Save();
             return;
         }
-
-        Accounts = JsonConvert.DeserializeObject<ObservableCollection<XivAccount>>(File.ReadAllText(this.configFile.FullName));
-
+        
         // If the file is corrupted, this will be null anyway
         Accounts ??= new ObservableCollection<XivAccount>();
+        
+        var accountsFromFile =
+            JsonConvert.DeserializeObject<ObservableCollection<XivAccount>>(File.ReadAllText(this.configFile.FullName));
+        if (accountsFromFile != null)
+        {
+            Accounts = accountsFromFile;   
+        }
     }
 
     #endregion

--- a/src/XIVLauncher.Core/AppUtil.cs
+++ b/src/XIVLauncher.Core/AppUtil.cs
@@ -15,7 +15,7 @@ public static partial class AppUtil
             throw new ArgumentException($"Resource {resourceName} not found", nameof(resourceName));
 
         var ret = new byte[s.Length];
-        s.Read(ret, 0, (int)s.Length);
+        s.ReadExactly(ret, 0, (int)s.Length);
         return ret;
     }
 

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -131,7 +131,7 @@ public class MainPage : Page
                 return;
             }
 
-            if (Repository.Ffxiv.GetVer(App.Settings.GamePath) == Constants.BASE_GAME_VERSION &&
+            if (Repository.Ffxiv.GetVer(App.Settings.GamePath!) == Constants.BASE_GAME_VERSION &&
                 App.Settings.IsUidCacheEnabled == true)
             {
                 App.ShowMessageBlocking(
@@ -246,8 +246,7 @@ public class MainPage : Page
 
             if (action == LoginAction.Repair)
                 return await App.Launcher.Login(username, password, otp, isSteam, false, gamePath, true, isFreeTrial, language).ConfigureAwait(false);
-            else
-                return await App.Launcher.Login(username, password, otp, isSteam, enableUidCache, gamePath, false, isFreeTrial, language).ConfigureAwait(false);
+            return await App.Launcher.Login(username, password, otp, isSteam, enableUidCache, gamePath, false, isFreeTrial, language).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -561,7 +560,7 @@ public class MainPage : Page
         Troubleshooting.LogTroubleshooting();
 
         var dalamudLauncher = new DalamudLauncher(dalamudRunner, Program.DalamudUpdater,
-            App.Settings.DalamudLoadMethod.GetValueOrDefault(DalamudLoadMethod.DllInject), App.Settings.GamePath,
+            App.Settings.DalamudLoadMethod.GetValueOrDefault(DalamudLoadMethod.DllInject), App.Settings.GamePath!,
             App.Storage.Root, App.Storage.GetFolder("logs"), App.Settings.ClientLanguage ?? ClientLanguage.English,
             App.Settings.DalamudLoadDelay, false, noPlugins, noThird, Troubleshooting.GetTroubleshootingJson());
 
@@ -585,7 +584,7 @@ public class MainPage : Page
             try
             {
                 App.StartLoading(Strings.WaitingForDalamud, Strings.PleaseBePatient);
-                dalamudOk = dalamudLauncher.HoldForUpdate(App.Settings.GamePath) == DalamudLauncher.DalamudInstallState.Ok;
+                dalamudOk = dalamudLauncher.HoldForUpdate(App.Settings.GamePath!) == DalamudLauncher.DalamudInstallState.Ok;
             }
             catch (DalamudRunnerException ex)
             {
@@ -748,12 +747,12 @@ public class MainPage : Page
 
         // We won't do any sanity checks here anymore, since that should be handled in StartLogin
         var launchedProcess = App.Launcher.LaunchGame(runner,
-            loginResult.UniqueId,
-            loginResult.OauthLogin.Region,
+            loginResult.UniqueId!,
+            loginResult.OauthLogin!.Region,
             loginResult.OauthLogin.MaxExpansion,
             isSteam,
             gameArgs,
-            App.Settings.GamePath,
+            App.Settings.GamePath!,
             App.Settings.ClientLanguage.GetValueOrDefault(ClientLanguage.English),
             App.Settings.IsEncryptArgs.GetValueOrDefault(true),
             App.Settings.DpiAwareness.GetValueOrDefault(DpiAwareness.Unaware));
@@ -891,7 +890,7 @@ public class MainPage : Page
 
         Debug.Assert(loginResult.PendingPatches != null, "loginResult.PendingPatches != null ASSERTION FAILED");
 
-        return TryHandlePatchAsync(Repository.Ffxiv, loginResult.PendingPatches, loginResult.UniqueId);
+        return TryHandlePatchAsync(Repository.Ffxiv, loginResult.PendingPatches, loginResult.UniqueId!);
     }
 
     private async Task<bool> TryHandlePatchAsync(Repository repository, PatchListEntry[] pendingPatches, string sid)
@@ -915,10 +914,10 @@ public class MainPage : Page
             return false;
         }
 
-        using var installer = new PatchInstaller(App.Settings.GamePath, App.Settings.KeepPatches ?? false);
+        using var installer = new PatchInstaller(App.Settings.GamePath!, App.Settings.KeepPatches ?? false);
         using var acquisition = new AriaPatchAcquisition(new FileInfo(Path.Combine(App.Storage.GetFolder("logs").FullName, "aria2.log")));
-        Program.Patcher = new PatchManager(acquisition, App.Settings.PatchSpeedLimit, repository, pendingPatches, App.Settings.GamePath,
-                                           App.Settings.PatchPath, installer, App.Launcher, sid);
+        Program.Patcher = new PatchManager(acquisition, App.Settings.PatchSpeedLimit, repository, pendingPatches, App.Settings.GamePath!,
+                                           App.Settings.PatchPath!, installer, App.Launcher, sid);
         Program.Patcher.OnFail += PatcherOnFail;
         installer.OnFail += this.InstallerOnFail;
 
@@ -951,7 +950,7 @@ public class MainPage : Page
                 {
                     Thread.Sleep(30);
 
-                    App.LoadingPage.Line2 = string.Format(Strings.WorkingOnStatus, Program.Patcher.CurrentInstallIndex, Program.Patcher.Downloads.Count);
+                    App.LoadingPage.Line2 = string.Format(Strings.WorkingOnStatus, Program.Patcher!.CurrentInstallIndex, Program.Patcher.Downloads.Count);
                     App.LoadingPage.Line3 = string.Format(Strings.LeftToDownloadStatus, MathHelpers.BytesToString(Program.Patcher.AllDownloadsLength < 0 ? 0 : Program.Patcher.AllDownloadsLength),
                         MathHelpers.BytesToString(Program.Patcher.Speeds.Sum()));
 
@@ -1049,7 +1048,7 @@ public class MainPage : Page
         Log.Information("STARTING REPAIR");
 
         // TODO: bundle the PatchInstaller with xl-core on Windows and run this remotely
-        using var verify = new PatchVerifier(Program.Config.GamePath!, Program.Config.PatchPath!, loginResult, TimeSpan.FromMilliseconds(100), loginResult.OauthLogin.MaxExpansion, false);
+        using var verify = new PatchVerifier(Program.Config.GamePath!, Program.Config.PatchPath!, loginResult, TimeSpan.FromMilliseconds(100), loginResult.OauthLogin!.MaxExpansion, false);
 
         for (var doVerify = true; doVerify;)
         {

--- a/src/XIVLauncher.Core/Configuration/Parsers/AddonListParser.cs
+++ b/src/XIVLauncher.Core/Configuration/Parsers/AddonListParser.cs
@@ -22,8 +22,12 @@ internal class AddonListParser : ITypeParser
     {
         if (t == typeof(List<AddonEntry>))
         {
-            result = JsonConvert.DeserializeObject<List<AddonEntry>>(value);
-            return true;
+            var deserialized = JsonConvert.DeserializeObject<List<AddonEntry>>(value);
+            if (deserialized != null)
+            {
+                result = deserialized;
+                return true;
+            }
         }
 
         result = null!;

--- a/src/XIVLauncher.Core/LauncherApp.cs
+++ b/src/XIVLauncher.Core/LauncherApp.cs
@@ -129,7 +129,7 @@ public class LauncherApp : Component
         this.Accounts = new AccountManager(this.Storage.GetFile("accounts.json"));
         this.UniqueIdCache = new CommonUniqueIdCache(this.Storage.GetFile("uidCache.json"));
 
-        this.Launcher = new Launcher(Program.Steam, UniqueIdCache, frontierUrl, Program.Config.AcceptLanguage ?? ApiHelpers.GenerateAcceptLanguage());
+        this.Launcher = new Launcher(Program.Steam, UniqueIdCache, frontierUrl, this.Settings.AcceptLanguage ?? ApiHelpers.GenerateAcceptLanguage());
 
         this.mainPage = new MainPage(this);
         this.setPage = new SettingsPage(this);
@@ -140,10 +140,10 @@ public class LauncherApp : Component
 
         if (!EnvironmentSettings.IsNoKillswitch && !string.IsNullOrEmpty(cutOffBootver))
         {
-            var bootver = SeVersion.Parse(Repository.Boot.GetVer(Program.Config.GamePath));
+            var bootVersion = SeVersion.Parse(Repository.Boot.GetVer(this.Settings.GamePath!));
             var cutoff = SeVersion.Parse(cutOffBootver);
 
-            if (bootver > cutoff)
+            if (bootVersion > cutoff)
             {
                 this.ShowMessage("XIVLauncher is unavailable at this time as there were changes to the login process during a recent patch." +
                                 "\n\nWe need to adjust to these changes and verify that our adjustments are safe before we can re-enable the launcher." +


### PR DESCRIPTION
This cleans up some of the warnings for null assignments or references

- The references to  `App.Settings.GamePath` are assured to not be null as it will either be loaded from the ini file or it is explicitly defined at the top level https://github.com/goatcorp/XIVLauncher.Core/blob/main/src/XIVLauncher.Core/Program.cs#L87
- The reference to `Program.Patcher` is initialized a few lines up
- The `loginResult`  will always contain the Oauth information at this point, as the errors are handled during login
- Lastly I changed the reference for `Program.Config` in LaucherApp to reference the Settings property for consistency.