### PR TITLE
Add version back into titlebar

### DIFF
--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -253,7 +253,8 @@ sealed class Program
 
         Log.Debug("Creating SDL3 devices...");
 
-        var version = AppUtil.GetGitHash();
+        var version = AppUtil.GetAssemblyVersion();
+        var hash = AppUtil.GetGitHash();
         unsafe
         {
             if (!SDL.Init(SDLInitFlags.Video | SDLInitFlags.Gamepad))
@@ -265,7 +266,7 @@ sealed class Program
             var mainScale = SDL.GetDisplayContentScale(SDL.GetPrimaryDisplay());
             var windowFlags = SDLWindowFlags.Resizable | SDLWindowFlags.Hidden | SDLWindowFlags.HighPixelDensity;
             window = SDL.CreateWindow(
-                $"XIVLauncher {version}",
+                $"XIVLauncher {version} ({hash})",
                 (int)(1280 * mainScale),
                 (int)(800 * mainScale),
                 windowFlags);


### PR DESCRIPTION
What it says on the tin. Titlebar got changed to just the hash in the SDL3 patch: XIVLauncher (hash). This restores it to "XIVLauncher 1.3.1 (hash)"