### PR TITLE
Allow setting Storage path to something besides ~/.xlcore

### DIFF
--- a/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
+++ b/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
@@ -18,6 +18,39 @@ public static class CoreEnvironmentSettings
     public static uint SteamAppId => GetAppId(Environment.GetEnvironmentVariable("SteamAppId"));
     public static uint AltAppID => GetAppId(Environment.GetEnvironmentVariable("XL_APPID"));
 
+    public static string? StoragePath => CheckEnvPath("XL_STORAGE_PATH");
+
+    private static string? CheckEnvPath(string key)
+    {
+        string rawPath = Environment.GetEnvironmentVariable(key) ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(rawPath))
+        {
+            return null;
+        }
+
+        // Validate for invalid path characters
+        if (rawPath.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
+        {
+            // Invalid path: contains illegal characters.
+            return null;
+        }
+
+        // Normalize and validate the path format
+        string fullPath;
+        try
+        {
+            fullPath = Path.GetFullPath(rawPath);
+        }
+        catch (Exception ex) when (ex is ArgumentException || ex is NotSupportedException || ex is PathTooLongException)
+        {
+            // Invalid path format
+            return null;
+        }
+
+        return fullPath;
+    }
+
     private static bool CheckEnvBool(string key)
     {
         string val = (Environment.GetEnvironmentVariable(key) ?? string.Empty).ToLower();

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -170,7 +170,7 @@ sealed class Program
     private static void Main(string[] args)
     {
         mainArgs = args;
-        storage = new Storage(APP_NAME);
+        storage = new Storage(APP_NAME, CoreEnvironmentSettings.StoragePath);
 
         if (CoreEnvironmentSettings.ClearAll)
         {


### PR DESCRIPTION
Added XL_STORAGE_PATH environment variable support to actually allow overriding the storage directory in Linux. The Storage class already had support for it, but there was no way to actually use it.