### PR TITLE
Autofocus the login button

### DIFF
--- a/src/XIVLauncher.Core/Components/Common/Button.cs
+++ b/src/XIVLauncher.Core/Components/Common/Button.cs
@@ -14,6 +14,8 @@ public class Button : Component
     public Vector4 TextColor { get; set; }
 
     public event Action? Click;
+    
+    public bool TakeKeyboardFocus { get; set; }
 
     public int? Width { get; set; }
 
@@ -33,6 +35,9 @@ public class Button : Component
         ImGui.PushStyleColor(ImGuiCol.Button, Color);
         ImGui.PushStyleColor(ImGuiCol.ButtonHovered, HoverColor);
         ImGui.PushStyleColor(ImGuiCol.Text, TextColor);
+        
+        if (TakeKeyboardFocus && ImGui.IsWindowAppearing())
+            ImGui.SetKeyboardFocusHere();
 
         if (ImGui.Button(Label, new Vector2(Width ?? -1, 0)) || (ImGui.IsItemFocused() && ImGui.IsKeyPressed(ImGuiKey.Enter)))
         {

--- a/src/XIVLauncher.Core/Components/MainPage/LoginFrame.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/LoginFrame.cs
@@ -80,7 +80,10 @@ public class LoginFrame : Component
         this.freeTrialCheckbox = new Checkbox(Strings.FreeTrialAccountCheckbox);
         this.autoLoginCheckbox = new Checkbox(Strings.LogInAutomaticCheckbox);
 
-        this.loginButton = new Button(Strings.LoginButton);
+        this.loginButton = new Button(Strings.LoginButton)
+        {
+            TakeKeyboardFocus = true
+        };
         this.loginButton.Click += TriggerLogin;
     }
 


### PR DESCRIPTION
This makes it possible to press enter after launch and start the login process.
Unlike the previous username autofocus solution this should not hinder users with virtual keyboards which I think fueled the revert in https://github.com/goatcorp/XIVLauncher.Core/pull/290.

Would partially solve or alleviate https://github.com/goatcorp/XIVLauncher.Core/issues/295.

I don't have a steamdeck so I can't test that this doesn't have unintended effects again.

@haysidney, @Blooym any feedback ?