### PR TITLE
feat: Add wine launch argument

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -129,6 +129,23 @@ public class CompatibilityTools
         return RunInPrefix(psi, workingDirectory, environment, redirectOutput, writeLog, wineD3D);
     }
 
+    public void RunInPrefixAndExit(string[] args, string workingDirectory = "", IDictionary<string, string> environment = null, bool wineD3D = false)
+    {
+        var psi = new ProcessStartInfo(Wine64Path);
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
+
+        psi.RedirectStandardInput = false;
+        psi.RedirectStandardOutput = false;
+        psi.RedirectStandardError = false;
+
+        var p = PrepareRunInPrefix(psi, workingDirectory, environment, false, wineD3D);
+        p.Start();
+
+        p.WaitForExit();
+        Environment.Exit(p.ExitCode);
+    }
+
     private void MergeDictionaries(StringDictionary a, IDictionary<string, string> b)
     {
         if (b is null)
@@ -143,10 +160,8 @@ public class CompatibilityTools
         }
     }
 
-    private Process RunInPrefix(ProcessStartInfo psi, string workingDirectory, IDictionary<string, string> environment, bool redirectOutput, bool writeLog, bool wineD3D)
+    private Process PrepareRunInPrefix(ProcessStartInfo psi, string workingDirectory, IDictionary<string, string> environment, bool canGamemode, bool wineD3D)
     {
-        psi.RedirectStandardOutput = redirectOutput;
-        psi.RedirectStandardError = writeLog;
         psi.UseShellExecute = false;
         psi.WorkingDirectory = workingDirectory;
 
@@ -174,7 +189,7 @@ public class CompatibilityTools
             _ => throw new ArgumentOutOfRangeException()
         };
 
-        if (this.gamemodeOn == true && !ldPreload.Contains("libgamemodeauto.so.0"))
+        if (canGamemode && this.gamemodeOn == true && !ldPreload.Contains("libgamemodeauto.so.0"))
         {
             ldPreload = ldPreload.Equals("", StringComparison.OrdinalIgnoreCase) ? "libgamemodeauto.so.0" : ldPreload + ":libgamemodeauto.so.0";
         }
@@ -197,6 +212,17 @@ public class CompatibilityTools
 
         Process helperProcess = new();
         helperProcess.StartInfo = psi;
+
+        return helperProcess;
+    }
+
+    private Process RunInPrefix(ProcessStartInfo psi, string workingDirectory, IDictionary<string, string> environment, bool redirectOutput, bool writeLog, bool wineD3D)
+    {
+        psi.RedirectStandardOutput = redirectOutput;
+        psi.RedirectStandardError = writeLog;
+
+        var helperProcess = PrepareRunInPrefix(psi, workingDirectory, environment, true, wineD3D);
+
         helperProcess.ErrorDataReceived += new DataReceivedEventHandler((_, errLine) =>
         {
             if (string.IsNullOrEmpty(errLine.Data))

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -126,6 +126,11 @@ public class SettingsTabWine : SettingsTab
             Program.CompatibilityTools.RunInPrefix("explorer");
         }
 
+        if (ImGui.IsItemHovered())
+        {
+            ImGui.SetTooltip(Strings.OpenWINEExplorerTooltip);
+        }
+
         if (ImGui.Button(Strings.KillAllWINEProcesses))
         {
             Program.CompatibilityTools.Kill();

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -199,6 +199,20 @@ sealed class Program
         SetupLogging(mainArgs);
         LoadConfig(storage);
 
+        if (args.Length >= 1 && args[0] == "wine")
+        {
+            if (args.Length == 1)
+            {
+                Console.WriteLine("Usage: xlcore wine taskmgr");
+                Environment.Exit(1);
+                return;
+            }
+
+            CreateCompatToolsInstance();
+            CompatibilityTools.RunInPrefixAndExit([.. args.Skip(1)]);
+            return;
+        }
+
         Secrets = GetSecretProvider(storage);
 
         Dictionary<uint, string> apps = [];

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.Designer.cs
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.Designer.cs
@@ -225,6 +225,12 @@ namespace XIVLauncher.Core.Resources.Localization {
             }
         }
         
+        internal static string OpenWINEExplorerTooltip {
+            get {
+                return ResourceManager.GetString("OpenWINEExplorerTooltip", resourceCulture);
+            }
+        }
+        
         internal static string KillAllWINEProcesses {
             get {
                 return ResourceManager.GetString("KillAllWINEProcesses", resourceCulture);

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.resx
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.resx
@@ -112,6 +112,9 @@ It should be an absolute path to a folder containing wine64 and wineserver binar
     <data name="OpenWINEExplorer" xml:space="preserve">
         <value>Open WINE explorer (run apps in prefix)</value>
     </data>
+    <data name="OpenWINEExplorerTooltip" xml:space="preserve">
+        <value>Tip: You can do the same via CLI: &lt;xlcore&gt; wine explorer</value>
+    </data>
     <data name="KillAllWINEProcesses" xml:space="preserve">
         <value>Kill all WINE processes</value>
     </data>


### PR DESCRIPTION
Acts as a proxy for wine in case you want to run cmd or vsdbg or anything else via the CLI or scripts in the same wine prefix.

~~Tooltip and CLI hint changes to rum on April 1st because it's a wine run pun, credit goes to Ny.~~  
Removed with latest force push, commit message updated to reflect this change too.

I wasn't sure how to regen the generated file from Linux, or whether or not to touch the localized files.
