### PR TITLE
fix: dont spin needlessly waiting for otp input

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -200,7 +200,7 @@ public class MainPage : Page
         if (isOtp && !App.UniqueIdCache.HasValidCache(username))
         {
             App.AskForOtp();
-            otp = App.WaitForOtp();
+            otp = await App.WaitForOtpAsync().ConfigureAwait(false);
 
             // Make sure we are loading again
             App.State = LauncherApp.LauncherState.Loading;

--- a/src/XIVLauncher.Core/Components/OtpEntryPage.cs
+++ b/src/XIVLauncher.Core/Components/OtpEntryPage.cs
@@ -14,9 +14,12 @@ public class OtpEntryPage : Page
     private string otp = string.Empty;
     private bool appearing = false;
     private OtpListener? otpListener;
+    private TaskCompletionSource<string?> resultTcs = new();
 
     public string? Result { get; private set; }
     public bool Cancelled { get; private set; }
+
+    public Task<string?> GetResultAsync() => this.resultTcs.Task;
 
     public OtpEntryPage(LauncherApp app) : base(app)
     {
@@ -25,10 +28,8 @@ public class OtpEntryPage : Page
 
     private void SteamOnOnGamepadTextInputDismissed(bool success)
     {
-        if (success)
-        {
-            if (Program.Steam is not null) this.Result = Program.Steam.GetEnteredGamepadText();
-        }
+        if (success && Program.Steam is not null)
+            TryAcceptOtp(Program.Steam.GetEnteredGamepadText());
     }
 
     public void Reset()
@@ -37,6 +38,7 @@ public class OtpEntryPage : Page
         this.appearing = true;
         this.Result = null;
         this.Cancelled = false;
+        this.resultTcs = new TaskCompletionSource<string?>();
 
         // TODO(goat): This doesn't work if you call it right after starting the app... Steam probably takes a little while to initialize. Might be annoying for autologin.
         // BUG: We have to turn this off when using OTP server, because there's no way to dismiss open keyboards
@@ -71,6 +73,7 @@ public class OtpEntryPage : Page
 
         Log.Verbose("Received OTP: {Otp}", otp);
         this.Result = otp;
+        this.resultTcs.TrySetResult(otp);
     }
 
     public void StartOtpListener()
@@ -135,6 +138,7 @@ public class OtpEntryPage : Page
             if (ImGui.Button(Strings.CancelLabel, buttonSize))
             {
                 this.Cancelled = true;
+                this.resultTcs.TrySetResult(null);
             }
         }
 

--- a/src/XIVLauncher.Core/LauncherApp.cs
+++ b/src/XIVLauncher.Core/LauncherApp.cs
@@ -223,14 +223,11 @@ public class LauncherApp : Component
         this.State = LauncherState.OtpEntry;
     }
 
-    public string? WaitForOtp()
+    public async Task<string?> WaitForOtpAsync()
     {
-        while (this.otpEntryPage.Result == null && !this.otpEntryPage.Cancelled)
-            Thread.Yield();
-
-        var res = this.otpEntryPage.Result;
+        var result = await this.otpEntryPage.GetResultAsync().ConfigureAwait(false);
         this.otpEntryPage.StopOtpListener();
-        return res;
+        return result;
     }
 
     public void StartLoading(string line1, string line2 = "", string line3 = "", bool isIndeterminate = true, bool canCancel = false, bool canDisableAutoLogin = false)


### PR DESCRIPTION
This change is a bit hacky and is not what I want to settle on, but for now it will help with ensuring the CPU is not spinning needlessly waiting while the OTP prompt is rendered