### PR TITLE
fix: respect hidden branches for dalamud

### DIFF
--- a/src/XIVLauncher.Core/Components/SettingsPage/DalamudBranchMetaSettingsEntry.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/DalamudBranchMetaSettingsEntry.cs
@@ -32,6 +32,7 @@ public class DalamudBranchMetaSettingsEntry : SettingsEntry<string>
         {
             foreach (var branch in this.Branches)
             {
+                if (branch.Hidden) continue;
                 if (ImGui.Selectable(branch.DisplayName, branch.Track == currentBranch?.Track))
                 {
                     this.SelectedBranch = branch;


### PR DESCRIPTION
Completely skipped my mind but showed up to be an issue during 7.5 updates. To avoid Core end users from accessing WIP builds