### PR TITLE
Add XDG_DATA_HOME as default storage location

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ Cross-platform version of XIVLauncher, optimized for Steam Deck. Comes with a ve
 ## Using on Steam Deck
 If you want to use XIVLauncher on your Steam Deck, feel free to [follow our guide in our FAQ](https://goatcorp.github.io/faq/steamdeck). If you're having trouble, you can [join our Discord server](https://discord.gg/3NMcUV5) - please don't use the GitHub issues for troubleshooting unless you're sure that your problem is an actual issue with XIVLauncher.
 
+## Environment Variables for troubleshooting
+| Variable      | Description    |
+| ------------- | -------------- |
+| `XL_USERDIR` | Set to an alternate path to override the default `$XDG_DATA_HOME/dev.goats.xivlauncher` config path. For example, `XL_USERDIR=~/.local/share/xlcore`. Potentially useful for dual-boxing. |
+| `XL_SECRET_PROVIDER` | Set to `file` if using the Steam Deck or other desktop session that doesn't have a secret provider. Set to `none` to disable secret provider. |
+| `XL_MAKE_SYMLINK` | Set to 0 to disable making a symlink at ~/.xlcore, or 1 to enable. Default is 1. |
+| `XL_DECK` | Force XIVLauncher to pretend it's Steam Deck. Does not enable the Steam keyboard. Mostly for |
+| `XL_GAMEMODE` | Forces XIVLauncher to pretend it's in Steam Deck Game Mode. Also does not enable the Steam keyboard. |
+| `XL_USE_STEAM` | Set to 0 or 1 to enable or disable steam API checks. |
+| `XL_APPID` | Set to a steam AppID number to hook that application instead of FFXIV or the free trial. Ignored when using XLM. |
+
 ## Building & Contributing
 1. Clone this repository with submodules
 2. Make sure you have a recent (.NET 10+) version of the .NET SDK installed

--- a/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
+++ b/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
@@ -17,6 +17,27 @@ public static class CoreEnvironmentSettings
     public static bool IsSteamCompatTool => CheckEnvBool("XL_SCT");
     public static uint SteamAppId => GetAppId(Environment.GetEnvironmentVariable("SteamAppId"));
     public static uint AltAppID => GetAppId(Environment.GetEnvironmentVariable("XL_APPID"));
+    
+    private static string? userDir = null;
+    public static string UserDir
+    {
+        get
+        {
+            if (userDir != null)
+                return userDir;
+
+            var uDir = Environment.GetEnvironmentVariable("XL_USERDIR") ?? "";
+            var uDir2 = Environment.GetEnvironmentVariable("XL_USER_DIR") ?? "";
+            var xlPath = Environment.GetEnvironmentVariable("XL_PATH") ?? "";
+            if (!string.IsNullOrEmpty(uDir))
+                userDir = uDir;
+            else if (!string.IsNullOrEmpty(uDir2))
+                userDir = uDir2;
+            else
+                userDir = xlPath;
+            return userDir;
+        }
+    }
 
     private static bool CheckEnvBool(string key)
     {

--- a/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
+++ b/src/XIVLauncher.Core/CoreEnvironmentSettings.cs
@@ -17,6 +17,7 @@ public static class CoreEnvironmentSettings
     public static bool IsSteamCompatTool => CheckEnvBool("XL_SCT");
     public static uint SteamAppId => GetAppId(Environment.GetEnvironmentVariable("SteamAppId"));
     public static uint AltAppID => GetAppId(Environment.GetEnvironmentVariable("XL_APPID"));
+    public static bool MakeSymlink => CheckEnvBool("XL_MAKE_SYMLINK", true);
     
     private static string? userDir = null;
     public static string UserDir
@@ -39,11 +40,12 @@ public static class CoreEnvironmentSettings
         }
     }
 
-    private static bool CheckEnvBool(string key)
+    private static bool CheckEnvBool(string key, bool defaultValue = false)
     {
         string val = (Environment.GetEnvironmentVariable(key) ?? string.Empty).ToLower();
         if (val == "1" || val == "true" || val == "yes" || val == "y" || val == "on") return true;
-        return false;
+        if (val == "0" || val == "false" || val == "no" || val == "n" || val == "off") return false;
+        return defaultValue;
     }
 
     private static bool? CheckEnvBoolOrNull(string key)

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -181,7 +181,9 @@ sealed class Program
     private static void Main(string[] args)
     {
         mainArgs = args;
-        storage = new Storage(APP_NAME);
+        // XDG will handle the storage path for Linux and Mac. It will fall back to the old ~/.xlcore path on Linux and Mac if it exists and the XDG path does not.
+        var userDir = XDG.GetStoragePath(APP_NAME, CoreEnvironmentSettings.UserDir);
+        storage = new Storage(APP_NAME, userDir);
 
         if (CoreEnvironmentSettings.ClearAll)
         {

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -36,7 +36,7 @@ namespace XIVLauncher.Core;
 
 sealed class Program
 {
-    private const string APP_NAME = "xlcore";
+    private const string APP_NAME = "dev.goats.xivlauncher";
     private static readonly Vector3 ClearColor = new(0.1f, 0.1f, 0.1f);
     private static string[] mainArgs = [];
     private static LauncherApp launcherApp = null!;
@@ -181,8 +181,8 @@ sealed class Program
     private static void Main(string[] args)
     {
         mainArgs = args;
-        // XDG will handle the storage path for Linux and Mac. It will fall back to the old ~/.xlcore path on Linux and Mac if it exists and the XDG path does not.
-        var userDir = XDG.GetStoragePath(APP_NAME);
+        // StorageHelper will handle moving old storage to the new XDG path if possible, and will return the correct path to use for storage.
+        var userDir = StorageHelper.GetStoragePath(APP_NAME);
         storage = new Storage(APP_NAME, userDir);
 
         if (CoreEnvironmentSettings.ClearAll)

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -182,7 +182,7 @@ sealed class Program
     {
         mainArgs = args;
         // XDG will handle the storage path for Linux and Mac. It will fall back to the old ~/.xlcore path on Linux and Mac if it exists and the XDG path does not.
-        var userDir = XDG.GetStoragePath(APP_NAME, CoreEnvironmentSettings.UserDir);
+        var userDir = XDG.GetStoragePath(APP_NAME);
         storage = new Storage(APP_NAME, userDir);
 
         if (CoreEnvironmentSettings.ClearAll)

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -36,7 +36,7 @@ namespace XIVLauncher.Core;
 
 sealed class Program
 {
-    private const string APP_NAME = "dev.goats.xivlauncher";
+    internal const string APP_NAME = "dev.goats.xivlauncher";
     private static readonly Vector3 ClearColor = new(0.1f, 0.1f, 0.1f);
     private static string[] mainArgs = [];
     private static LauncherApp launcherApp = null!;
@@ -182,8 +182,10 @@ sealed class Program
     {
         mainArgs = args;
         // StorageHelper will handle moving old storage to the new XDG path if possible, and will return the correct path to use for storage.
-        var userDir = StorageHelper.GetStoragePath(APP_NAME);
+        var userDir = StorageHelper.GetStoragePath();
         storage = new Storage(APP_NAME, userDir);
+        if (CoreEnvironmentSettings.MakeSymlink)
+            StorageHelper.MakeSymlink(storage.Root.FullName);
 
         if (CoreEnvironmentSettings.ClearAll)
         {

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -489,7 +489,7 @@ sealed class Program
     public static void FixConfigPaths()
     {
         Config.GamePath = StorageHelper.FixConfigPath(Config.GamePath);
-        Config.GameConfigPath = StorageHelper.FixConfigPath(Config.GamePath);
+        Config.GameConfigPath = StorageHelper.FixConfigPath(Config.GameConfigPath);
         Config.PatchPath = StorageHelper.FixConfigPath(Config.PatchPath);
         Config.WineBinaryPath = StorageHelper.FixConfigPath(Config.WineBinaryPath);
         Config.DalamudManualInjectPath = StorageHelper.FixConfigPath(Config.DalamudManualInjectPath);

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -202,6 +202,7 @@ sealed class Program
 
         SetupLogging(mainArgs);
         LoadConfig(storage);
+        FixConfigPaths();
 
         Secrets = GetSecretProvider(storage);
 
@@ -483,6 +484,15 @@ sealed class Program
         ClearPlugins(tsbutton);
         ClearTools(tsbutton);
         ClearLogs(true);
+    }
+
+    public static void FixConfigPaths()
+    {
+        Config.GamePath = StorageHelper.FixConfigPath(Config.GamePath);
+        Config.GameConfigPath = StorageHelper.FixConfigPath(Config.GamePath);
+        Config.PatchPath = StorageHelper.FixConfigPath(Config.PatchPath);
+        Config.WineBinaryPath = StorageHelper.FixConfigPath(Config.WineBinaryPath);
+        Config.DalamudManualInjectPath = StorageHelper.FixConfigPath(Config.DalamudManualInjectPath);
     }
 
     public static void ResetUIDCache(bool tsbutton = false) => launcherApp.UniqueIdCache.Reset();

--- a/src/XIVLauncher.Core/StorageHelper.cs
+++ b/src/XIVLauncher.Core/StorageHelper.cs
@@ -51,7 +51,7 @@ public static class StorageHelper
 
     public static void MakeSymlink(string storagePath)
     {
-        if (OperatingSystem.IsWindows() || CoreEnvironmentSettings.UserDir != null)
+        if (OperatingSystem.IsWindows() || !string.IsNullOrEmpty(CoreEnvironmentSettings.UserDir))
         {
             return; // Do not create symlink on Windows, or if a custom user directory is set.
         }

--- a/src/XIVLauncher.Core/StorageHelper.cs
+++ b/src/XIVLauncher.Core/StorageHelper.cs
@@ -117,4 +117,42 @@ public static class StorageHelper
             Console.WriteLine($"Warning:Failed to create symlink at {oldPath} to {storageTarget}");
         }
     }
+
+    public static string? FixConfigPath(string configPath)
+    {
+        if (OperatingSystem.IsWindows() || !string.IsNullOrEmpty(CoreEnvironmentSettings.UserDir) || configPath == null)
+            return configPath; // Do not modify the path on Windows, or if a custom user directory is set.
+
+        if (Path.Combine(Program.storage.Root.FullName) == Path.Combine(oldPath))
+            return configPath; // If the storage path is still the old path, do not modify the config ini path.
+
+        if (configPath.StartsWith(oldPath))
+            return Path.Combine(ReplaceFirst(configPath, oldPath, Program.storage.Root.FullName)); // Return the modified path.
+
+        return configPath; // Return the original path if it does not need to be modified.
+    }
+
+    public static DirectoryInfo? FixConfigPath(DirectoryInfo configPath)
+    {
+        if (OperatingSystem.IsWindows() || !string.IsNullOrEmpty(CoreEnvironmentSettings.UserDir) || configPath == null)
+            return configPath; // Do not modify the path on Windows, or if a custom user directory is set.
+
+        if (Path.Combine(Program.storage.Root.FullName) == Path.Combine(oldPath))
+            return configPath; // If the storage path is still the old path, do not modify the config ini path.
+
+        if (configPath.FullName.StartsWith(oldPath))
+            return new DirectoryInfo(Path.Combine(ReplaceFirst(configPath.FullName, oldPath, Program.storage.Root.FullName))); // Return the modified path.
+
+        return configPath; // Return the original path if it does not need to be modified.
+    }
+
+    private static string ReplaceFirst(string text, string search, string replace)
+    {
+      int pos = text.IndexOf(search);
+      if (pos < 0)
+      {
+        return text;
+      }
+      return text[..pos] + replace + text[(pos + search.Length)..];
+    }
 }

--- a/src/XIVLauncher.Core/StorageHelper.cs
+++ b/src/XIVLauncher.Core/StorageHelper.cs
@@ -51,9 +51,9 @@ public static class StorageHelper
 
     public static void MakeSymlink(string storagePath)
     {
-        if (OperatingSystem.IsWindows())
+        if (OperatingSystem.IsWindows() || CoreEnvironmentSettings.UserDir != null)
         {
-            return; // Do not create symlink on Windows.
+            return; // Do not create symlink on Windows, or if a custom user directory is set.
         }
 
         // This should only happen if XDG_DATA_HOME is on a separate volume from HOME.

--- a/src/XIVLauncher.Core/StorageHelper.cs
+++ b/src/XIVLauncher.Core/StorageHelper.cs
@@ -1,26 +1,25 @@
 using System.IO;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 using XIVLauncher.Common;
 
 namespace XIVLauncher.Core;
 
-public static class XDG
+public static class StorageHelper
 {
     private static Platform platform;
 
-    static XDG()
+    static StorageHelper()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             platform = Platform.Win32;
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        else if (OperatingSystem.IsLinux())
         {
             platform = Platform.Linux;
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        else if (OperatingSystem.IsMacOS())
         {
             platform = Platform.Mac;
         }
@@ -30,6 +29,8 @@ public static class XDG
         }
     }
 
+    // Returns null if we're using the default storage path for the platform, or ~/.xlcore on Linux/Mac if it exists and can't be moved.
+    // Returns the XL_USERDIR if it's set. This overrides all other paths and is mostly here for dual-boxing.
     public static string? GetStoragePath(string appName)
     {
         if (!string.IsNullOrEmpty(CoreEnvironmentSettings.UserDir))
@@ -42,12 +43,12 @@ public static class XDG
         }
         else if (platform == Platform.Linux  || platform == Platform.Mac)
         {
-            var xdgStoragePath = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), $"dev.goats.{appName}"));
-            var oldStoragePath = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), $".{appName}"));
+            var xdgStoragePath = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appName));
+            var oldStoragePath = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), $".xlcore"));
             if (xdgStoragePath.Exists)
             {
-                return xdgStoragePath.FullName; // Use XDG Base Directory spec path if it exists. This is ~/.local/share/dev.goats.xlcore on Linux and ~/Library/Application Support/dev.goats.xlcore on Mac.
-                                                // This can be overridden with the XL_USERDIR environment variable, which will take precedence over both the old path and the XDG path.
+                return null;    // Use XDG Base Directory spec path if it exists. This is ~/.local/share on Linux and ~/Library/Application Support on Mac.
+                                // This can be overridden with the XL_USERDIR environment variable, which will take precedence over both the old path and the XDG path.
             }
             if (oldStoragePath.Exists)
             {
@@ -60,7 +61,7 @@ public static class XDG
                 }
                 return oldStoragePath.FullName; // In case Storage class gets modified before this XDG class gets removed.
             }
-            return xdgStoragePath.FullName; // Use XDG Base Directory spec path for new installs on Linux and Mac.
+            return null;    // Use XDG Base Directory spec path for new installs on Linux and Mac.
         }
         else
         {

--- a/src/XIVLauncher.Core/StorageHelper.cs
+++ b/src/XIVLauncher.Core/StorageHelper.cs
@@ -72,9 +72,37 @@ public static class StorageHelper
             return;
         }
 
-        // Catch an edge case where the user did some unusual manual symlinking.
-        if (Directory.Exists(oldPath))
+        // Catch broken or incorrect symlinks at ~/.xlcore
+        if (Directory.Exists(oldPath) || File.Exists(oldPath))
         {
+            var isDirectory = File.GetAttributes(oldPath).HasFlag(FileAttributes.Directory);
+
+            var oldTarget = isDirectory ? Directory.ResolveLinkTarget(oldPath, true) : File.ResolveLinkTarget(oldPath, true);
+            if (oldTarget is null)
+            {
+                Console.WriteLine($"Warning: {oldPath} exists but is not a symlink. Please remove or rename it and restart the launcher to create a symlink at {oldPath}.");
+                return; // ~/.xlcore is not a symlink. Don't do anything.
+            }
+            if (Path.Combine(oldTarget.FullName) != Path.Combine(storagePath))
+            {
+                try
+                {
+                    if (isDirectory)
+                    {
+                        Directory.Delete(oldPath);
+                    }
+                    else
+                    {
+                        File.Delete(oldPath);
+                    }
+                    Directory.CreateSymbolicLink(oldPath, storagePath);
+                }
+                catch (System.Exception ex)
+                {                    
+                    Console.WriteLine(ex.Message);
+                    Console.WriteLine($"Warning: Failed to update symlink at {oldPath} to point to {storagePath}. Please manually update the symlink or remove {oldPath} and restart the launcher to use the new XDG storage location.");
+                }
+            }
             return;
         }
 

--- a/src/XIVLauncher.Core/StorageHelper.cs
+++ b/src/XIVLauncher.Core/StorageHelper.cs
@@ -29,127 +29,40 @@ public static class StorageHelper
         }
     }
 
-    // Returns null if we're using the default storage path for the platform, or ~/.xlcore on Linux/Mac if it exists and can't be moved.
-    // Returns the XL_USERDIR if it's set. This overrides all other paths and is mostly here for dual-boxing.
     public static string? GetStoragePath(string appName)
     {
         if (!string.IsNullOrEmpty(CoreEnvironmentSettings.UserDir))
         {
-            return CoreEnvironmentSettings.UserDir; // If the XL_USERDIR environment variable is set, use it as the storage path. This takes precedence over all other paths.
+            return CoreEnvironmentSettings.UserDir;
         }
+
         if (platform == Platform.Win32)
         {
-            return null; // Let Storage class handle it. Windows works fine.
+            return null; // Use default storage on Windows.
         }
-        else if (platform == Platform.Linux  || platform == Platform.Mac)
-        {
-            var xdgStoragePath = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appName));
-            var oldStoragePath = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), $".xlcore"));
-            if (xdgStoragePath.Exists)
-            {
-                return null;    // Use XDG Base Directory spec path if it exists. This is ~/.local/share on Linux and ~/Library/Application Support on Mac.
-                                // This can be overridden with the XL_USERDIR environment variable, which will take precedence over both the old path and the XDG path.
-            }
-            if (oldStoragePath.Exists)
-            {
-                // We will check to see if ~/.xlcore is on the same drive as the new XDG path. If it is, we can move it to the new location.
-                // If it's not, we will leave it in place and use it as the storage path, since moving it would take forever and hang the program.
-                if (IsMovable(oldStoragePath.FullName, xdgStoragePath.FullName))
-                {
-                    oldStoragePath.MoveTo(xdgStoragePath.FullName); // Move ~/.xlcore to new XDG path, since it's confirmed to be on the same drive.
-                    return xdgStoragePath.FullName;
-                }
-                return oldStoragePath.FullName; // In case Storage class gets modified before this XDG class gets removed.
-            }
-            return null;    // Use XDG Base Directory spec path for new installs on Linux and Mac.
-        }
-        else
-        {
-            throw new PlatformNotSupportedException("Unsupported platform");
-        }
-    }
 
-    private static bool IsMovable(string oldFolder, string newFolder)
-    {
-        // Future implementation note: Dotnet 11 preview currently allows for the testing hardlinks, which would allow us to try creating a hardlink
-        // from a testfile in the old folder to one in the new folder. If it succeeded, we'd know they were on the same drive.
-        try
-        {
-            var drives = DriveInfo.GetDrives();
-            int oldHitCounter = 0;
-            int newHitCounter = 0;
-
-            // Use realpath to resolve symlinks. This is important for bazzite, SteamOS and other immutable distros.
-            oldFolder = GetRealPath(oldFolder);
-            newFolder = GetRealPath(newFolder);
-            if (oldFolder == null || newFolder == null)
-            {
-                return false; // If we can't resolve the real paths, we assume the move failed and return false.
-            }
-            
-            // Unix dotnet enumerates drives for each mounted path, including various virtual filesystems like /proc and /sys.
-            // To determine if two folders are on the same drive, we'll match them to mount points and count the hits.
-            // This is to get around edge cases where someone did something weird like mount a partition to ~/.xlcore or ~/.local/share.
-            // If they match the same number of mount points, we can be reasonably sure they're on the same partition, and safe to move.
-            foreach (var drive in drives)
-            {
-                if (oldFolder.StartsWith(drive.RootDirectory.FullName))
-                {
-                    oldHitCounter++;
-                }
-                if (newFolder.StartsWith(drive.RootDirectory.FullName))
-                {
-                    newHitCounter++;
-                }
-            }
-            if (oldHitCounter == newHitCounter && oldHitCounter > 0)
-            {
-                return true;
-            }
-            return false; // The files are on different drives, so they are not movable.
-        }
-        catch
-        {
-            return false; // If any exception occurs, we assume the move failed and return false.
-        }
-    }
-
-    private static string? GetRealPath(string path)
-    {
-        // There's no good way to resolve the real path of a file in .NET on Linux and MacOS,
-        // since .NET doesn't have a built-in way to do it and the behavior of Path.GetFullPath is inconsistent across platforms.
-        // The best we can do is to call the "realpath" command-line utility, which is available on both Linux and MacOS.
+        var xdgStoragePath = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appName));       // new default storage path
+        var oldStoragePath = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".xlcore"));              // legacy path for xivlauncher
         
-        // This should work on Linux and MacOS, but not Windows. It should never be called from Windows, but just in case:
-        if (platform == Platform.Win32)
+        if (xdgStoragePath.Exists)
         {
-            return null;
+            return null; 
         }
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = "realpath",
-            Arguments = path,
-            RedirectStandardOutput = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
-        using (var process = new Process { StartInfo = startInfo })
+
+        if (oldStoragePath.Exists)
         {
             try
             {
-                process.Start();
-                string realPath = process.StandardOutput.ReadToEnd().Trim();
-                process.WaitForExit();
-                if (process.ExitCode != 0)
-                {
-                    return null;
-                }
-                return realPath;
+                oldStoragePath.MoveTo(xdgStoragePath.FullName); // Move ~/.xlcore to new XDG path.
+                return null;
             }
-            catch
+            catch (System.Exception)
             {
-                return null; // If any exception occurs, we assume we can't resolve the path and return null.
+                Console.WriteLine($"Failed to move directory from {oldStoragePath.FullName} to {xdgStoragePath.FullName}");
+                return oldStoragePath.FullName; // Return the old storage path ~/.xlcore if the move failed.
             }
         }
+        
+        return null; // If no storage directory exists, return null to use the default path.
     }
 }

--- a/src/XIVLauncher.Core/StorageHelper.cs
+++ b/src/XIVLauncher.Core/StorageHelper.cs
@@ -9,41 +9,25 @@ public static class StorageHelper
 {
     private static Platform platform;
 
-    static StorageHelper()
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            platform = Platform.Win32;
-        }
-        else if (OperatingSystem.IsLinux())
-        {
-            platform = Platform.Linux;
-        }
-        else if (OperatingSystem.IsMacOS())
-        {
-            platform = Platform.Mac;
-        }
-        else
-        {
-            throw new PlatformNotSupportedException("Unsupported platform");
-        }
-    }
+    private static string xdgPath => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), Program.APP_NAME);
 
-    public static string? GetStoragePath(string appName)
+    private static string oldPath => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".xlcore");
+
+    public static string? GetStoragePath()
     {
         if (!string.IsNullOrEmpty(CoreEnvironmentSettings.UserDir))
         {
             return CoreEnvironmentSettings.UserDir;
         }
 
-        if (platform == Platform.Win32)
+        if (OperatingSystem.IsWindows())
         {
             return null; // Use default storage on Windows.
         }
 
-        var xdgStoragePath = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appName));       // new default storage path
-        var oldStoragePath = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".xlcore"));              // legacy path for xivlauncher
-        
+        var xdgStoragePath = new DirectoryInfo(xdgPath);
+        var oldStoragePath = new DirectoryInfo(oldPath);
+       
         if (xdgStoragePath.Exists)
         {
             return null; 
@@ -58,11 +42,51 @@ public static class StorageHelper
             }
             catch (System.Exception)
             {
-                Console.WriteLine($"Failed to move directory from {oldStoragePath.FullName} to {xdgStoragePath.FullName}");
+                Console.WriteLine($"Warning: Failed to move directory from {oldStoragePath.FullName} to {xdgStoragePath.FullName}");
                 return oldStoragePath.FullName; // Return the old storage path ~/.xlcore if the move failed.
             }
         }
-        
         return null; // If no storage directory exists, return null to use the default path.
+    }
+
+    public static void MakeSymlink(string storagePath)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return; // Do not create symlink on Windows.
+        }
+
+        // This should only happen if XDG_DATA_HOME is on a separate volume from HOME.
+        // Make a symlink at XDG_DATA_HOME/dev.goats.xivlauncher pointing to ~/.xlcore
+        if (Path.Combine(storagePath) == Path.Combine(oldPath))
+        {
+            var oldTarget = Directory.ResolveLinkTarget(oldPath, true)?.FullName ?? oldPath;
+            try
+            {
+                Directory.CreateSymbolicLink(xdgPath, oldTarget);
+            }
+            catch (System.Exception)
+            {
+                Console.WriteLine($"Warning: Failed to create symlink at {xdgPath} to {oldTarget}");
+            }
+            return;
+        }
+
+        // Catch an edge case where the user did some unusual manual symlinking.
+        if (Directory.Exists(oldPath))
+        {
+            return;
+        }
+
+        // Make a symlink at ~/.xlcore pointing to the storage path
+        var storageTarget = Directory.ResolveLinkTarget(storagePath, true)?.FullName ?? storagePath;
+        try
+        {
+            Directory.CreateSymbolicLink(oldPath, storageTarget);
+        }
+        catch (System.Exception)
+        {
+            Console.WriteLine($"Warning:Failed to create symlink at {oldPath} to {storageTarget}");
+        }
     }
 }

--- a/src/XIVLauncher.Core/XDG.cs
+++ b/src/XIVLauncher.Core/XDG.cs
@@ -1,0 +1,59 @@
+using System.IO;
+
+using XIVLauncher.Common;
+
+namespace XIVLauncher.Core;
+
+public static class XDG
+{
+    private static Platform platform;
+
+    static XDG()
+    {
+        if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+        {
+            platform = Platform.Win32;
+        }
+        else if (Environment.OSVersion.Platform == PlatformID.Unix)
+        {
+            platform = Platform.Linux;
+        }
+        else if (Environment.OSVersion.Platform == PlatformID.MacOSX)
+        {
+            platform = Platform.Mac;
+        }
+        else
+        {
+            throw new PlatformNotSupportedException("Unsupported platform");
+        }
+    }
+    public static string? GetStoragePath(string appName, string? overridePath = null)
+    {
+        if (!string.IsNullOrEmpty(overridePath))
+        {
+            return overridePath;
+        }
+        if (platform == Platform.Win32)
+        {
+            return null; // Let Storage class handle it. Windows works fine.
+        }
+        else if (platform == Platform.Linux  || platform == Platform.Mac)
+        {
+            if (Directory.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appName)))
+            {
+                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appName); // Use XDG Base Directory spec path if it exists.
+                                                                                                                         // This is ~/.local/share/xlcore on Linux and ~/Library/Application Support/xlcore on Mac.
+                                                                                                                         // This can be overridden with the XL_USERDIR environment variable, which will take precedence over both the old path and the XDG path.
+            }
+            if (Directory.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), $".{appName}")))
+            {
+                return null; // Let Storage class handle it and use the old ~/.xlcore path if it exists, and the XDG_DATA_HOME/xlcore directory does not exist.
+            }
+            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appName); // Use XDG Base Directory spec path for new installs on Linux and Mac.
+        }
+        else
+        {
+            throw new PlatformNotSupportedException("Unsupported platform");
+        }
+    }
+}

--- a/src/XIVLauncher.Core/XDG.cs
+++ b/src/XIVLauncher.Core/XDG.cs
@@ -1,4 +1,6 @@
 using System.IO;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 using XIVLauncher.Common;
 
@@ -10,15 +12,15 @@ public static class XDG
 
     static XDG()
     {
-        if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             platform = Platform.Win32;
         }
-        else if (Environment.OSVersion.Platform == PlatformID.Unix)
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
             platform = Platform.Linux;
         }
-        else if (Environment.OSVersion.Platform == PlatformID.MacOSX)
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
             platform = Platform.Mac;
         }
@@ -27,11 +29,12 @@ public static class XDG
             throw new PlatformNotSupportedException("Unsupported platform");
         }
     }
-    public static string? GetStoragePath(string appName, string? overridePath = null)
+
+    public static string? GetStoragePath(string appName)
     {
-        if (!string.IsNullOrEmpty(overridePath))
+        if (!string.IsNullOrEmpty(CoreEnvironmentSettings.UserDir))
         {
-            return overridePath;
+            return CoreEnvironmentSettings.UserDir; // If the XL_USERDIR environment variable is set, use it as the storage path. This takes precedence over all other paths.
         }
         if (platform == Platform.Win32)
         {
@@ -39,21 +42,113 @@ public static class XDG
         }
         else if (platform == Platform.Linux  || platform == Platform.Mac)
         {
-            if (Directory.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appName)))
+            var xdgStoragePath = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), $"dev.goats.{appName}"));
+            var oldStoragePath = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), $".{appName}"));
+            if (xdgStoragePath.Exists)
             {
-                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appName); // Use XDG Base Directory spec path if it exists.
-                                                                                                                         // This is ~/.local/share/xlcore on Linux and ~/Library/Application Support/xlcore on Mac.
-                                                                                                                         // This can be overridden with the XL_USERDIR environment variable, which will take precedence over both the old path and the XDG path.
+                return xdgStoragePath.FullName; // Use XDG Base Directory spec path if it exists. This is ~/.local/share/dev.goats.xlcore on Linux and ~/Library/Application Support/dev.goats.xlcore on Mac.
+                                                // This can be overridden with the XL_USERDIR environment variable, which will take precedence over both the old path and the XDG path.
             }
-            if (Directory.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), $".{appName}")))
+            if (oldStoragePath.Exists)
             {
-                return null; // Let Storage class handle it and use the old ~/.xlcore path if it exists, and the XDG_DATA_HOME/xlcore directory does not exist.
+                // We will check to see if ~/.xlcore is on the same drive as the new XDG path. If it is, we can move it to the new location.
+                // If it's not, we will leave it in place and use it as the storage path, since moving it would take forever and hang the program.
+                if (IsMovable(oldStoragePath.FullName, xdgStoragePath.FullName))
+                {
+                    oldStoragePath.MoveTo(xdgStoragePath.FullName); // Move ~/.xlcore to new XDG path, since it's confirmed to be on the same drive.
+                    return xdgStoragePath.FullName;
+                }
+                return oldStoragePath.FullName; // In case Storage class gets modified before this XDG class gets removed.
             }
-            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appName); // Use XDG Base Directory spec path for new installs on Linux and Mac.
+            return xdgStoragePath.FullName; // Use XDG Base Directory spec path for new installs on Linux and Mac.
         }
         else
         {
             throw new PlatformNotSupportedException("Unsupported platform");
+        }
+    }
+
+    private static bool IsMovable(string oldFolder, string newFolder)
+    {
+        // Future implementation note: Dotnet 11 preview currently allows for the testing hardlinks, which would allow us to try creating a hardlink
+        // from a testfile in the old folder to one in the new folder. If it succeeded, we'd know they were on the same drive.
+        try
+        {
+            var drives = DriveInfo.GetDrives();
+            int oldHitCounter = 0;
+            int newHitCounter = 0;
+
+            // Use realpath to resolve symlinks. This is important for bazzite, SteamOS and other immutable distros.
+            oldFolder = GetRealPath(oldFolder);
+            newFolder = GetRealPath(newFolder);
+            if (oldFolder == null || newFolder == null)
+            {
+                return false; // If we can't resolve the real paths, we assume the move failed and return false.
+            }
+            
+            // Unix dotnet enumerates drives for each mounted path, including various virtual filesystems like /proc and /sys.
+            // To determine if two folders are on the same drive, we'll match them to mount points and count the hits.
+            // This is to get around edge cases where someone did something weird like mount a partition to ~/.xlcore or ~/.local/share.
+            // If they match the same number of mount points, we can be reasonably sure they're on the same partition, and safe to move.
+            foreach (var drive in drives)
+            {
+                if (oldFolder.StartsWith(drive.RootDirectory.FullName))
+                {
+                    oldHitCounter++;
+                }
+                if (newFolder.StartsWith(drive.RootDirectory.FullName))
+                {
+                    newHitCounter++;
+                }
+            }
+            if (oldHitCounter == newHitCounter && oldHitCounter > 0)
+            {
+                return true;
+            }
+            return false; // The files are on different drives, so they are not movable.
+        }
+        catch
+        {
+            return false; // If any exception occurs, we assume the move failed and return false.
+        }
+    }
+
+    private static string? GetRealPath(string path)
+    {
+        // There's no good way to resolve the real path of a file in .NET on Linux and MacOS,
+        // since .NET doesn't have a built-in way to do it and the behavior of Path.GetFullPath is inconsistent across platforms.
+        // The best we can do is to call the "realpath" command-line utility, which is available on both Linux and MacOS.
+        
+        // This should work on Linux and MacOS, but not Windows. It should never be called from Windows, but just in case:
+        if (platform == Platform.Win32)
+        {
+            return null;
+        }
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "realpath",
+            Arguments = path,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        using (var process = new Process { StartInfo = startInfo })
+        {
+            try
+            {
+                process.Start();
+                string realPath = process.StandardOutput.ReadToEnd().Trim();
+                process.WaitForExit();
+                if (process.ExitCode != 0)
+                {
+                    return null;
+                }
+                return realPath;
+            }
+            catch
+            {
+                return null; // If any exception occurs, we assume we can't resolve the path and return null.
+            }
         }
     }
 }


### PR DESCRIPTION
This patch adds $XDG_DATA_HOME (default: ~/.local/share) as the default location for the xlcore folder. This (better) obeys the XDG desktop specification. Ideally, the ini files would go in $XDG_CONFIG_HOME/xlcore (default: ~/.config), but that would require extensive reworking of the storage system, and isn't really worth it. I'm using $XDG_DATA_HOME because $XDG_CONFIG_HOME really shouldn't be used to store large amounts of data. It's not uncommon for people to back up ~/.config to a git repo, for example.

* $XDG_DATA_HOME/xlcore will be used if it exists
* ~/.xlcore will be the fallback if the above is not found and ~/.xlcore is found
* $XDG_DATA_HOME/xlcore will be created and used if neither of the above are true
* $XL_USER_DIR / $XL_USERDIR / $XL_PATH can be used to override the default storage location. Necessary for dual-boxing.

Edit to add:
In the interest of full disclosure, I think VSCode has enabled AI generation by default, because it kept finishing my code blocks and comments for me. I did not *ask* it to do anything, or prompt it, it just kept completing my code blocks, and occasionally adding extra parenthesis and semicolons in the wrong spot. I tried turning it off, but it kept "fixing" my code. So a bit of this is technically AI generated, though it *is* what I intended to do.

It is very annoying, and I think I'm going to ditch VSCode now, because sometimes I hit tab to indent, and it decides to generate a new function that doesn't work or even do anything useful. 