### PR TITLE
fix: reduce cpu and memory usage

### DIFF
--- a/src/XIVLauncher.Core/ImGuiBindings.cs
+++ b/src/XIVLauncher.Core/ImGuiBindings.cs
@@ -8,6 +8,8 @@ using Hexa.NET.SDL3;
 
 using HexaGen.Runtime;
 
+using Serilog;
+
 using ImSDLEvent = Hexa.NET.ImGui.Backends.SDL3.SDLEvent;
 using ImSDLGPUCommandBuffer = Hexa.NET.ImGui.Backends.SDL3.SDLGPUCommandBuffer;
 using ImSDLGPUDevice = Hexa.NET.ImGui.Backends.SDL3.SDLGPUDevice;
@@ -218,7 +220,10 @@ public class ImGuiBindings : IDisposable
         }
 
         SDLGPUTexture* swapTexture;
-        SDL.AcquireGPUSwapchainTexture(commandBuffer, this.window, &swapTexture, null, null);
+        if (!SDL.WaitAndAcquireGPUSwapchainTexture(commandBuffer, this.window, &swapTexture, null, null))
+        {
+            Log.Error($"Error: SDL.WaitAndAcquireGPUSwapchainTexture(): {SDL.GetErrorS()}");
+        }
 
         if (swapTexture != null && !isMinimized)
         {


### PR DESCRIPTION
noticed this was using excessive cpu (approx 100% of a core, switching cores frequently). found it's caused by using
SDL.AcquireGPUSwapchainTexture without external timing. as noted at [1],

> If you use this function, it is possible to create a situation where many command buffers are allocated while the rendering context waits for the GPU to catch up, which will cause memory usage to grow. You should use SDL_WaitAndAcquireGPUSwapchainTexture() unless you know what you are doing with timing.

so, change to use SDL_WaitAndAcquireGPUSwapchainTexture(), which has the effect of frame limiting to vsync as was likely intended.

[1] https://wiki.libsdl.org/SDL3/SDL_AcquireGPUSwapchainTexture