### PR TITLE
Set application icon from within XIVLauncher.Core

### DIFF
--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -289,8 +289,13 @@ sealed class Program
                 Environment.Exit(1);
             }
 
-            icon = GetApplicationIcon();
-            SDL.SetWindowIcon(window, icon);
+            if (TryGetApplicationIcon(out icon))
+            {
+                if (!SDL.SetWindowIcon(window, icon))
+                {
+                    Log.Error($"Error: SDL_SetWindowIcon(): {SDL.GetErrorS()}");
+                }
+            }
             SDL.SetWindowPosition(window, (int)SDL.SDL_WINDOWPOS_CENTERED_MASK, (int)SDL.SDL_WINDOWPOS_CENTERED_MASK);
             Log.Debug("SDL OK!");
 
@@ -488,29 +493,60 @@ sealed class Program
 
     public static void ResetUIDCache(bool tsbutton = false) => launcherApp.UniqueIdCache.Reset();
 
-    private static unsafe SDLSurface* GetApplicationIcon()
+    private static unsafe bool TryGetApplicationIcon(out SDLSurface* icon)
     {
         var logoImage = AppUtil.GetEmbeddedResourceBytes("logo.png").AsMemory();
         using var handle = logoImage.Pin();
-        var tempicon = SDLImage.LoadPNGIO(SDL.IOFromMem(handle.Pointer, (nuint) logoImage.Length));
+        var sdlIoStream = SDL.IOFromMem(handle.Pointer, (nuint) logoImage.Length);
+        if (sdlIoStream is null)
+        {
+            Log.Error($"Error: SDL_IOFromMem(): {SDL.GetErrorS()}");
+            icon = null;
+            return false;
+        }
+        var tempicon = SDLImage.LoadPNGIO(sdlIoStream);
         if (tempicon is null)
         {
-            Log.Error($"Error: SDL_LoadPNG_IO failed: {SDL.GetErrorS()}");
-            return SDL.CreateSurface(0,0,SDLPixelFormat.Abgr8888);
+            Log.Error($"Error: SDL_LoadPNG_IO(): {SDL.GetErrorS()}");
+            icon = null;
+            return false;
         }
 
         var applicationIcon = SDL.ScaleSurface(tempicon, 512, 512, SDLScaleMode.Linear);
+        if (applicationIcon is null)
+        {
+            Log.Error($"Error: SDL_ScaleSurface() (512x512): {SDL.GetErrorS()}");
+            icon = null;
+            return false;
+        }
 
         // Sizes smaller than 64x64 don't look good on my machine
         int[] alternateSizes = [64, 96, 128, 256];
         foreach(var size in alternateSizes)
         {
             var alternateIcon = SDL.ScaleSurface(tempicon, size, size, SDLScaleMode.Linear);
-            SDL.AddSurfaceAlternateImage(applicationIcon, alternateIcon);
+            if (alternateIcon is null)
+            {
+                Log.Error($"Error: SDL_ScaleSurface() ({size}x{size}): {SDL.GetErrorS()}");
+                SDL.DestroySurface(applicationIcon);
+                SDL.DestroySurface(alternateIcon);
+                icon = null;
+                return false;
+            }
+            if (!SDL.AddSurfaceAlternateImage(applicationIcon, alternateIcon))
+            {
+                Log.Error($"Error: SDL_AddSurfaceAlternateImage() ({size}x{size}): {SDL.GetErrorS()}");
+                SDL.DestroySurface(applicationIcon);
+                SDL.DestroySurface(alternateIcon);
+                icon = null;
+                return false;
+            }
+            
             SDL.DestroySurface(alternateIcon);
         }
 
         SDL.DestroySurface(tempicon);
-        return applicationIcon;
+        icon = applicationIcon;
+        return true;
     }
 }

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using Config.Net;
 
 using Hexa.NET.SDL3;
+using Hexa.NET.SDL3.Image;
 
 using Serilog;
 
@@ -41,6 +42,7 @@ sealed class Program
     private static string[] mainArgs = [];
     private static LauncherApp launcherApp = null!;
     private static unsafe SDLWindow* window = null!;
+    private static unsafe SDLSurface* icon = null!;
     private static unsafe SDLGPUDevice* gpuDevice = null!;
     public static unsafe SDLGPUDevice* GPUDevice => gpuDevice;
     private static ImGuiBindings guiBindings = null!;
@@ -287,6 +289,8 @@ sealed class Program
                 Environment.Exit(1);
             }
 
+            icon = GetApplicationIcon();
+            SDL.SetWindowIcon(window, icon);
             SDL.SetWindowPosition(window, (int)SDL.SDL_WINDOWPOS_CENTERED_MASK, (int)SDL.SDL_WINDOWPOS_CENTERED_MASK);
             Log.Debug("SDL OK!");
 
@@ -336,6 +340,7 @@ sealed class Program
             guiBindings.Dispose();
             SDL.ReleaseWindowFromGPUDevice(gpuDevice, window);
             SDL.DestroyGPUDevice(gpuDevice);
+            SDL.DestroySurface(icon);
             SDL.DestroyWindow(window);
             SDL.Quit();
 
@@ -482,4 +487,30 @@ sealed class Program
     }
 
     public static void ResetUIDCache(bool tsbutton = false) => launcherApp.UniqueIdCache.Reset();
+
+    private static unsafe SDLSurface* GetApplicationIcon()
+    {
+        var logoImage = AppUtil.GetEmbeddedResourceBytes("logo.png").AsMemory();
+        using var handle = logoImage.Pin();
+        var tempicon = SDLImage.LoadPNGIO(SDL.IOFromMem(handle.Pointer, (nuint) logoImage.Length));
+        if (tempicon is null)
+        {
+            Log.Error($"Error: SDL_LoadPNG_IO failed: {SDL.GetErrorS()}");
+            return SDL.CreateSurface(0,0,SDLPixelFormat.Abgr8888);
+        }
+
+        var applicationIcon = SDL.ScaleSurface(tempicon, 512, 512, SDLScaleMode.Linear);
+
+        // Sizes smaller than 64x64 don't look good on my machine
+        int[] alternateSizes = [64, 96, 128, 256];
+        foreach(var size in alternateSizes)
+        {
+            var alternateIcon = SDL.ScaleSurface(tempicon, size, size, SDLScaleMode.Linear);
+            SDL.AddSurfaceAlternateImage(applicationIcon, alternateIcon);
+            SDL.DestroySurface(alternateIcon);
+        }
+
+        SDL.DestroySurface(tempicon);
+        return applicationIcon;
+    }
 }


### PR DESCRIPTION
So turns out we've been relying on desktop environments to set icons for us, when we could have done that ourselves. Thankfully, since I last touched SDL in this project, we switched to a better C# wrapper, so this was halfway painless. 

I am giving SDL the ability to choose from multiple alternate sizes as appropriate for the use case. Initially it was going to contain 48x48, 32x32, 24x24, and 16x16 as alternate sizes as well, like the (in XLCore unused) dalamud_icon.ico provides, but it didn't look good on my machine. I considered using the ico file, but SDL will only actually look at the highest resolution image within it, so I would have to roll my own image loader, which is entirely beyond the scope of this. 

During testing on both X11 and Wayland, the new application icon graced my title bar for the first time since switching to XLCore from XL for Windows. It also sets my taskbar icon properly, though I had to remove the currently existing .desktop file because I couldn't see any changes otherwise. We may want to consider removing the StartupWMClass in it or consider setting it to `ffxiv_dx11.exe`, like someone else suggested, to share the XIVLauncher icon with the game.
Before: 
<img width="285" height="37" alt="image" src="https://github.com/user-attachments/assets/c2f09771-46d2-427f-a91f-b74e4516da6e" />
After: 
<img width="289" height="35" alt="image" src="https://github.com/user-attachments/assets/d01f049b-be61-45a9-a3b1-1b24b08b54dd" />

Fixes #363. 
