### PR TITLE
Linux: Use game window class as `StartupWMClass`

### DIFF
--- a/misc/linux_distrib/XIVLauncher.desktop
+++ b/misc/linux_distrib/XIVLauncher.desktop
@@ -6,4 +6,4 @@ Icon=xivlauncher
 Terminal=false
 Type=Application
 Categories=Game;PackageManager;
-StartupWMClass=XIVLauncher.Core
+StartupWMClass=ffxiv_dx11.exe


### PR DESCRIPTION
Hey there,

so ever since I started using XIVLauncher it always bothered me that its icon is visible for a whole 10 seconds before being replaced by FFXIV's low-resolution-upscale default icon, which is in all honesty a little ugly.

I started digging into a way to fix this, and that's where `StartupWMClass` in this PR comes in.

While I'm using the RPM on Fedora, and from what I've been told the `.desktop` file here is merely intended as a reference, I wanted to submit this change here first. If this is not desired there's no point in me filing PRs against the RPM and Flathub package either.

---

The `StartupWMClass` is intended as a hint for desktop environments to associate a window that is NOT spawned directly by the "application entry" (= `.desktop` file) with said application entry. In other words, it is intended for windows spawned by a launcher, but are separate from the launcher.
The [Desktop Entry spec](https://specifications.freedesktop.org/desktop-entry/1.5/recognized-keys.html) is very vague in this, but a post on [askubuntu](https://askubuntu.com/a/367851/450196) provides a clearer explanation.

In XIVLauncher's case, the "application entry" starts XIVLauncher itself, which therefore does not require a hint for association.

The window being spawned from XIVLauncher is of course the game (or rather its Wine window).

While `StartupWMClass` is not required for the launcher itself, we can use this mechanism to overwrite FFXIV's default low-resolution icon with that of XIVLauncher. This consequently also follows a user's icon theme if it provides an icon for XIVLauncher.

Wine automatically sets the `WM_CLASS` to the application's [executable name](https://bugs.winehq.org/show_bug.cgi?id=50095). Since Wine is always spawning an X11 window (even under Wayland through XWayland), we can retrieve and confirm this using `xprop`:

```
xprop WM_CLASS
WM_CLASS(STRING) = "ffxiv_dx11.exe", "ffxiv_dx11.exe"
```

Therefore, setting `StartupWMClass` to `ffxiv_dx11.exe` allows us to use the same icon for both XIVLauncher and FFXIV.

---

How has this been tested:

All tests done on Plasma Wayland (6.7).

In the first step I removed the `StartupWMClass` entirely and I confirmed that the window still retained its icon in the taskbar. Pinning to the taskbar also did not result in 2 separate entries upon launch.

I then added it back with the value changed and confirmed that the icon was used for the game as well.

---

This change has one minor side effect:

Because this associates the window with the application entry, this also changes the Game's window title in the taskbar and when Alt-Tabbing:

<img width="306" height="281" alt="image" src="https://github.com/user-attachments/assets/e546b466-8f4a-499c-bbe4-420de8b82699" />

As you can see the "real" title is moved to a ... sub(?)title (IDK what the correct terminology is for this).

This is also why it took a couple days to open the PR after the commit, because I wanted to make sure this doesn't have unintended consequences. But from my testing, it doesn't actually make a difference and is purely cosmetic.

My main worry was that because the window titles are the same, this could result in unintentional captures via window capture (in OBS or Discord screen sharing for example).

But in my testing, the capture selection uses the "real" window title as opposed to the "adopted" window title from the desktop file. This applies to both X11 (XComposite) and Wayland (xdg-desktop-portal) capture.

I don't have a GNOME session to test with, so if anyone could confirm it's the same there, that would be nice.

---

I also noticed that the Taskbar icon is lost when launched through Lutris, but this should be fixed by #364 once XL sets its own window icon.

---

Note: If and when Wine ever goes Wayland native, this will likely stop working. But given the current state of their Wayland driver, that's probably still a few years out at best.