### PR TITLE
More lenient game path requirement

### DIFF
--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
@@ -18,7 +18,7 @@ public class SettingsTabGame : SettingsTab
 
                 try
                 {
-                    if ((x.Name is "game" or "boot") && x.Exists && x.GetFileSystemInfos().Length > 0)
+                    if ((x.Name is "game" or "boot") && x.Exists && x.EnumerateFileSystemInfos().Any())
                         return Strings.GamePathSettingInvalidValidationj;
                 }
                 catch (Exception)

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
@@ -16,8 +16,14 @@ public class SettingsTabGame : SettingsTab
                 if (string.IsNullOrWhiteSpace(x?.FullName))
                     return Strings.GamePathSettingNotSetValidation;
 
-                if (x.Name is "game" or "boot")
-                    return Strings.GamePathSettingInvalidValidationj;
+                try
+                {
+                    if ((x.Name is "game" or "boot") && x.Exists && x.GetFileSystemInfos().Length > 0)
+                        return Strings.GamePathSettingInvalidValidationj;
+                }
+                catch (Exception)
+                {
+                }
 
                 return null;
             }


### PR DESCRIPTION
Hi there!,

I was trying to set custom paths like `/foo/ffxiv/game` and `/foo/ffxiv/config` and noticed that this was not allowed. The game installation uses sub paths `game` and `boot`, and XIVLauncher therefore blocks paths ending in "game" or "boot" as an added safety precaution to prevent the user from selecting wrong existing paths.  But this safety precaution only really applies to existing paths filled with game content. So I've made it so this validation is skipped in case the folder is empty, hopefully allowing XIVLauncher to create paths like `/foo/ffxiv/game/game` and `/foo/ffxiv/game/boot`.

Disclaimer: I did not test whether this logic actually works or not, but I'm hoping the change is simple enough that no testing is needed.