### PR TITLE
feat: add Discord RPC Bridge to XIVLauncher.Common.Unix

### DIFF
--- a/src/XIVLauncher.Common.Unix/UnixDiscordRpcRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixDiscordRpcRunner.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using DiscordRPCBridge_Wine;
+
+namespace XIVLauncher.Common.Unix;
+
+public class UnixDiscordRpcRunner(int? port = null)
+{
+    private readonly RPCBridgeServer rpcBridge = new RPCBridgeServer();
+    private readonly int? port = port;
+
+    public void StartRpcBridge()
+    {
+        if (this.port.HasValue)
+        {
+            this.rpcBridge.Start(this.port.Value);
+            return;
+        }
+        this.rpcBridge.Start();
+    }
+    public async Task StopRpcBridge() => 
+        await this.rpcBridge.StopAsync().ConfigureAwait(false);
+}

--- a/src/XIVLauncher.Common.Unix/XIVLauncher.Common.Unix.csproj
+++ b/src/XIVLauncher.Common.Unix/XIVLauncher.Common.Unix.csproj
@@ -22,8 +22,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference
-            Include="..\..\lib\FFXIVQuickLauncher\src\XIVLauncher.Common\XIVLauncher.Common.csproj" />
+        <ProjectReference Include="..\..\lib\FFXIVQuickLauncher\src\XIVLauncher.Common\XIVLauncher.Common.csproj" />
     </ItemGroup>
 
     <PropertyGroup Label="Configuration" Condition="'$(Configuration)'=='Release'">
@@ -33,6 +32,7 @@
 
     <ItemGroup>
         <!-- Custom steamworks, based on the chippy branch of Facepunch.Steamworks -->
+        <PackageReference Include="DiscordRPCBridge-Wine" Version="1.0.0" />
         <PackageReference Include="goaaats.Steamworks" Version="2.3.4" />
     </ItemGroup>
 </Project>

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -27,6 +27,8 @@ namespace XIVLauncher.Core.Components.MainPage;
 
 public class MainPage : Page
 {
+    private UnixDiscordRpcRunner? rpcRunner;
+    
     private readonly LoginFrame loginFrame;
     private readonly NewsFrame newsFrame;
     private readonly ActionButtons actionButtons;
@@ -686,11 +688,13 @@ public class MainPage : Page
                 if (App.Settings.WineBinaryPath == null)
                     throw new InvalidOperationException("Custom wine binary path wasn't set.");
                 else if (!Directory.Exists(App.Settings.WineBinaryPath))
-                    throw new InvalidOperationException("Custom wine binary path is invalid: no such directory.\n" +
-                                                        "Check path carefully for typos: " + App.Settings.WineBinaryPath);
+                    throw new InvalidOperationException(
+                        "Custom wine binary path is invalid: no such directory.\n" +
+                        "Check path carefully for typos: " + App.Settings.WineBinaryPath);
                 else if (!File.Exists(Path.Combine(App.Settings.WineBinaryPath, "wine64")))
-                    throw new InvalidOperationException("Custom wine binary path is invalid: no wine64 found at that location.\n" +
-                                                        "Check path carefully for typos: " + App.Settings.WineBinaryPath);
+                    throw new InvalidOperationException(
+                        "Custom wine binary path is invalid: no wine64 found at that location.\n" +
+                        "Check path carefully for typos: " + App.Settings.WineBinaryPath);
 
                 Log.Information("Using Custom Wine: " + App.Settings.WineBinaryPath);
             }
@@ -703,19 +707,21 @@ public class MainPage : Page
             var signal = new ManualResetEvent(false);
             var isFailed = false;
 
-            var _ = Task.Run(async () =>
-            {
-                var tempPath = App.Storage.GetFolder("temp");
-                await Program.CompatibilityTools.EnsureTool(Program.HttpClient, tempPath).ConfigureAwait(false);
-            }).ContinueWith(t =>
-            {
-                isFailed = t.IsFaulted || t.IsCanceled;
+            var _ = Task.Run(
+                async () =>
+                {
+                    var tempPath = App.Storage.GetFolder("temp");
+                    await Program.CompatibilityTools.EnsureTool(Program.HttpClient, tempPath).ConfigureAwait(false);
+                }).ContinueWith(
+                t =>
+                {
+                    isFailed = t.IsFaulted || t.IsCanceled;
 
-                if (isFailed)
-                    Log.Error(t.Exception, "Couldn't ensure compatibility tool");
+                    if (isFailed)
+                        Log.Error(t.Exception, "Couldn't ensure compatibility tool");
 
-                signal.Set();
-            });
+                    signal.Set();
+                });
 
             App.StartLoading(Strings.PreparingForCompatTool, Strings.PleaseBePatient);
             signal.WaitOne();
@@ -723,6 +729,38 @@ public class MainPage : Page
 
             if (isFailed)
                 return null!;
+
+            // Start RPC bridge
+            if (App.Settings.UseDiscordRpcBridge ?? false)
+            {
+                var rpcSignal = new ManualResetEvent(false);
+                isFailed = false;
+                
+                var rpcTask = Task.Run(
+                    () =>
+                    {
+                        this.rpcRunner = App.Settings.DiscordRpcUseCustomPort ?? false
+                                             ? new UnixDiscordRpcRunner(App.Settings.DiscordRpcCustomPort)
+                                             : new UnixDiscordRpcRunner();
+                        this.rpcRunner.StartRpcBridge();
+                    }).ContinueWith(
+                    t =>
+                    {
+                        isFailed = t.IsFaulted || t.IsCanceled;
+
+                        if (isFailed)
+                            Log.Error(t.Exception, "Couldn't start Discord RPC Bridge");
+
+                        rpcSignal.Set();
+                    });
+                
+                App.StartLoading(Strings.StartingRPC, Strings.PleaseBePatient);
+                rpcSignal.WaitOne();
+                rpcSignal.Dispose();
+
+                if (isFailed)
+                    return null!;
+            }
 
             App.StartLoading(Strings.StartingGame, Strings.HaveFun);
 
@@ -795,7 +833,10 @@ public class MainPage : Page
         await Task.Run(() => launchedProcess!.WaitForExit()).ConfigureAwait(false);
 
         Log.Verbose("Game has exited");
-
+        
+        if (this.rpcRunner != null)
+            await this.rpcRunner.StopRpcBridge().ConfigureAwait(false);
+        
         if (addonMgr.IsRunning)
             addonMgr.StopAddons();
 

--- a/src/XIVLauncher.Core/Components/SettingsPage/SettingsEntry{T}.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/SettingsEntry{T}.cs
@@ -59,6 +59,17 @@ public class SettingsEntry<T> : SettingsEntry
                 this.InternalValue = nativeBuffer;
             }
         }
+        else if (type == typeof(int))
+        {
+            ImGuiHelpers.TextWrapped(this.Name);
+
+            var nativeValue = this.Value as int? ?? 2026;
+            
+            if (ImGui.InputInt($"###{Id.ToString()}", ref nativeValue, step: 0))
+            {
+                this.InternalValue = nativeValue; 
+            }
+        }
         else if (type == typeof(bool))
         {
             var nativeValue = this.Value as bool? ?? false;

--- a/src/XIVLauncher.Core/Components/SettingsPage/SettingsEntry{T}.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/SettingsEntry{T}.cs
@@ -63,7 +63,7 @@ public class SettingsEntry<T> : SettingsEntry
         {
             ImGuiHelpers.TextWrapped(this.Name);
 
-            var nativeValue = this.Value as int? ?? 2026;
+            var nativeValue = this.Value as int? ?? 0;
             
             if (ImGui.InputInt($"###{Id.ToString()}", ref nativeValue, step: 0))
             {

--- a/src/XIVLauncher.Core/Components/SettingsPage/SettingsEntry{T}.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/SettingsEntry{T}.cs
@@ -59,17 +59,6 @@ public class SettingsEntry<T> : SettingsEntry
                 this.InternalValue = nativeBuffer;
             }
         }
-        else if (type == typeof(int))
-        {
-            ImGuiHelpers.TextWrapped(this.Name);
-
-            var nativeValue = this.Value as int? ?? 2026;
-            
-            if (ImGui.InputInt($"###{Id.ToString()}", ref nativeValue, step: 0))
-            {
-                this.InternalValue = nativeValue; 
-            }
-        }
         else if (type == typeof(bool))
         {
             var nativeValue = this.Value as bool? ?? false;

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
@@ -7,40 +7,58 @@ namespace XIVLauncher.Core.Components.SettingsPage.Tabs;
 
 public class SettingsTabGame : SettingsTab
 {
-    public override SettingsEntry[] Entries { get; } =
+    public override SettingsEntry[] Entries { get;  }
+    private readonly SettingsEntry<bool> enableDiscordRpc;
+    private readonly SettingsEntry<bool> enableDiscordRpcCustomPort;
+
+    public SettingsTabGame()
     {
-        new SettingsEntry<DirectoryInfo>(Strings.GamePathSetting, Strings.GamePathSettingDescription, () => Program.Config.GamePath, x => Program.Config.GamePath = x)
+        this.Entries = new SettingsEntry[]
         {
-            CheckValidity = x =>
+            new SettingsEntry<DirectoryInfo>(Strings.GamePathSetting, Strings.GamePathSettingDescription, () => Program.Config.GamePath, x => Program.Config.GamePath = x)
             {
-                if (string.IsNullOrWhiteSpace(x?.FullName))
-                    return Strings.GamePathSettingNotSetValidation;
+                CheckValidity = x =>
+                {
+                    if (string.IsNullOrWhiteSpace(x?.FullName))
+                        return Strings.GamePathSettingNotSetValidation;
 
-                if (x.Name is "game" or "boot")
-                    return Strings.GamePathSettingInvalidValidationj;
+                    if (x.Name is "game" or "boot")
+                        return Strings.GamePathSettingInvalidValidationj;
 
-                return null;
-            }
-        },
+                    return null;
+                }
+            },
 
-        new SettingsEntry<DirectoryInfo>(Strings.GameConfigurationPathSetting, Strings.GameConfigurationPathSettingDescription, () => Program.Config.GameConfigPath, x => Program.Config.GameConfigPath = x)
-        {
-            CheckValidity = x => string.IsNullOrWhiteSpace(x?.FullName) ? Strings.GameConfigurationPathNotSetValidation : null,
+            new SettingsEntry<DirectoryInfo>(Strings.GameConfigurationPathSetting, Strings.GameConfigurationPathSettingDescription, () => Program.Config.GameConfigPath, x => Program.Config.GameConfigPath = x)
+            {
+                CheckValidity = x => string.IsNullOrWhiteSpace(x?.FullName) ? Strings.GameConfigurationPathNotSetValidation : null,
 
-            // TODO: We should also support this on Windows
-            CheckVisibility = () => Environment.OSVersion.Platform == PlatformID.Unix,
-        },
+                // TODO: We should also support this on Windows
+                CheckVisibility = () => Environment.OSVersion.Platform == PlatformID.Unix,
+            },
 
-        new SettingsEntry<string>(Strings.AdditionalGameArgsSetting, Strings.AdditionalGameArgsSettingDescription, () => Program.Config.AdditionalArgs, x => Program.Config.AdditionalArgs = x),
-        new SettingsEntry<ClientLanguage>(Strings.GameLanguageSetting, Strings.GameLanguageSettingDescription, () => Program.Config.ClientLanguage ?? ClientLanguage.English, x => Program.Config.ClientLanguage = x),
-        new SettingsEntry<DpiAwareness>(Strings.GameDPIAwarenessSetting, Strings.GameDPIAwarenessSettingDescription, () => Program.Config.DpiAwareness ?? DpiAwareness.Unaware, x => Program.Config.DpiAwareness = x),
-        new SettingsEntry<bool>(Strings.UseXLAuthMacrosSetting, Strings.UseXLAuthMacrosSettingDescription, () => Program.Config.IsOtpServer ?? false, x => Program.Config.IsOtpServer = x),
-        new SettingsEntry<bool>(Strings.IgnoreSteamSetting, Strings.IgnoreSteamSettingDescription, () => Program.Config.IsIgnoringSteam ?? false, x => Program.Config.IsIgnoringSteam = x)
-        {
-            CheckVisibility = () => !CoreEnvironmentSettings.IsSteamCompatTool,
-        },
-        new SettingsEntry<bool>(Strings.UseUIDCacheSetting, Strings.UseUIDCacheSettingDescription, () => Program.Config.IsUidCacheEnabled ?? false, x => Program.Config.IsUidCacheEnabled = x),
-    };
+            new SettingsEntry<string>(Strings.AdditionalGameArgsSetting, Strings.AdditionalGameArgsSettingDescription, () => Program.Config.AdditionalArgs, x => Program.Config.AdditionalArgs = x),
+            new SettingsEntry<ClientLanguage>(Strings.GameLanguageSetting, Strings.GameLanguageSettingDescription, () => Program.Config.ClientLanguage ?? ClientLanguage.English, x => Program.Config.ClientLanguage = x),
+            new SettingsEntry<DpiAwareness>(Strings.GameDPIAwarenessSetting, Strings.GameDPIAwarenessSettingDescription, () => Program.Config.DpiAwareness ?? DpiAwareness.Unaware, x => Program.Config.DpiAwareness = x),
+
+            enableDiscordRpc = new SettingsEntry<bool>(Strings.UseDiscordRPCBridgeSetting, Strings.UseDiscordRPCBridgeDescription, () => Program.Config.UseDiscordRpcBridge ?? false, x => Program.Config.UseDiscordRpcBridge = x),
+            this.enableDiscordRpcCustomPort = new SettingsEntry<bool>(Strings.DiscordRPCUseCustomPortSetting, Strings.DiscordRPCUseCustomPortDescription, () => Program.Config.DiscordRpcUseCustomPort ?? false, x => Program.Config.DiscordRpcUseCustomPort = x)
+            {
+                CheckVisibility = () => enableDiscordRpc.Value,
+            },
+            new SettingsEntry<int>(Strings.DiscordRPCCustomPortSetting, Strings.DiscordRPCCustomPortDescription, () => Program.Config.DiscordRpcCustomPort ?? 2026, x => Program.Config.DiscordRpcCustomPort = x)
+            {
+                CheckValidity = (port) => (port is < 1024 or > 49151) ? Strings.PortNumberMustBeBetween : null,
+                CheckVisibility = () => this.enableDiscordRpcCustomPort.Value,
+            },
+            new SettingsEntry<bool>(Strings.UseXLAuthMacrosSetting, Strings.UseXLAuthMacrosSettingDescription, () => Program.Config.IsOtpServer ?? false, x => Program.Config.IsOtpServer = x),
+            new SettingsEntry<bool>(Strings.IgnoreSteamSetting, Strings.IgnoreSteamSettingDescription, () => Program.Config.IsIgnoringSteam ?? false, x => Program.Config.IsIgnoringSteam = x)
+            {
+                CheckVisibility = () => !CoreEnvironmentSettings.IsSteamCompatTool,
+            },
+            new SettingsEntry<bool>(Strings.UseUIDCacheSetting, Strings.UseUIDCacheSettingDescription, () => Program.Config.IsUidCacheEnabled ?? false, x => Program.Config.IsUidCacheEnabled = x),
+        };
+    }
 
     public override string Title => Strings.GameTitle;
 

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
@@ -46,9 +46,8 @@ public class SettingsTabGame : SettingsTab
             {
                 CheckVisibility = () => enableDiscordRpc.Value,
             },
-            new SettingsEntry<int>(Strings.DiscordRPCCustomPortSetting, Strings.DiscordRPCCustomPortDescription, () => Program.Config.DiscordRpcCustomPort ?? 2026, x => Program.Config.DiscordRpcCustomPort = x)
+            new NumericSettingsEntry(Strings.DiscordRPCCustomPortSetting, Strings.DiscordRPCCustomPortDescription, () => Program.Config.DiscordRpcCustomPort ?? 2026, x => Program.Config.DiscordRpcCustomPort = x, 1024, 49151, 0)
             {
-                CheckValidity = (port) => (port is < 1024 or > 49151) ? Strings.PortNumberMustBeBetween : null,
                 CheckVisibility = () => this.enableDiscordRpcCustomPort.Value,
             },
             new SettingsEntry<bool>(Strings.UseXLAuthMacrosSetting, Strings.UseXLAuthMacrosSettingDescription, () => Program.Config.IsOtpServer ?? false, x => Program.Config.IsOtpServer = x),

--- a/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
+++ b/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
@@ -42,6 +42,12 @@ public interface ILauncherConfig
 
     public bool? IsIgnoringSteam { get; set; }
 
+    public bool? UseDiscordRpcBridge { get; set; }
+    
+    public bool? DiscordRpcUseCustomPort { get; set; }
+
+    public int? DiscordRpcCustomPort { get; set; }
+
     #region Patching
 
     public DirectoryInfo? PatchPath { get; set; }

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.Designer.cs
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.Designer.cs
@@ -531,6 +531,18 @@ namespace XIVLauncher.Core.Resources.Localization {
             }
         }
         
+        internal static string UseDiscordRPCBridgeSetting {
+            get {
+                return ResourceManager.GetString("UseDiscordRPCBridgeSetting", resourceCulture);
+            }
+        }
+        
+        internal static string UseDiscordRPCBridgeDescription {
+            get {
+                return ResourceManager.GetString("UseDiscordRPCBridgeDescription", resourceCulture);
+            }
+        }
+        
         internal static string UseXLAuthMacrosSetting {
             get {
                 return ResourceManager.GetString("UseXLAuthMacrosSetting", resourceCulture);
@@ -921,6 +933,12 @@ namespace XIVLauncher.Core.Resources.Localization {
             }
         }
         
+        internal static string StartingRPC {
+            get {
+                return ResourceManager.GetString("StartingRPC", resourceCulture);
+            }
+        }
+        
         internal static string StartingGame {
             get {
                 return ResourceManager.GetString("StartingGame", resourceCulture);
@@ -1062,6 +1080,36 @@ namespace XIVLauncher.Core.Resources.Localization {
         internal static string EnableFsyncSettingUnsupportedPlatformValidation {
             get {
                 return ResourceManager.GetString("EnableFsyncSettingUnsupportedPlatformValidation", resourceCulture);
+            }
+        }
+        
+        internal static string DiscordRPCUseCustomPortSetting {
+            get {
+                return ResourceManager.GetString("DiscordRPCUseCustomPortSetting", resourceCulture);
+            }
+        }
+        
+        internal static string DiscordRPCUseCustomPortDescription {
+            get {
+                return ResourceManager.GetString("DiscordRPCUseCustomPortDescription", resourceCulture);
+            }
+        }
+        
+        internal static string DiscordRPCCustomPortSetting {
+            get {
+                return ResourceManager.GetString("DiscordRPCCustomPortSetting", resourceCulture);
+            }
+        }
+        
+        internal static string DiscordRPCCustomPortDescription {
+            get {
+                return ResourceManager.GetString("DiscordRPCCustomPortDescription", resourceCulture);
+            }
+        }
+        
+        internal static string PortNumberMustBeBetween {
+            get {
+                return ResourceManager.GetString("PortNumberMustBeBetween", resourceCulture);
             }
         }
     }

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.de.resx
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.de.resx
@@ -571,4 +571,28 @@ You may have to reinstall the game.</value>
   <data name="EnableFsyncSettingUnsupportedPlatformValidation" xml:space="preserve">
         <value>FSync is only available on Linux</value>
     </data>
+    <data name="StartingRPC" xml:space="preserve">
+        <value>Starting the Discord RPC bridge</value>
+    </data>
+    <data name="UseDiscordRPCBridgeDescription" xml:space="preserve">
+        <value>Check this to enable the Discord Rich Presence Bridge when launching the game (only needed for some Wine/Proton builds).</value>
+    </data>
+    <data name="UseDiscordRPCBridgeSetting" xml:space="preserve">
+        <value>Use Discord Rich Presence Bridge</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortDescription" xml:space="preserve">
+        <value>Set to customize the port Discord RPC communicates on (Port must also be set in the Discord RPC plugin).</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortSetting" xml:space="preserve">
+        <value>Use Custom RPC Port</value>
+    </data>
+    <data name="DiscordRPCCustomPortDescription" xml:space="preserve">
+        <value>Set what port Discord RPC should communicate on.</value>
+    </data>
+    <data name="DiscordRPCCustomPortSetting" xml:space="preserve">
+        <value>Custom RPC Port</value>
+    </data>
+    <data name="PortNumberMustBeBetween" xml:space="preserve">
+        <value>Port number must be between 1024-49151</value>
+    </data>
 </root>

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.es.resx
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.es.resx
@@ -571,4 +571,28 @@ Quizá tengas que reinstalar el juego.</value>
   <data name="EnableFsyncSettingUnsupportedPlatformValidation" xml:space="preserve">
         <value>FSync sólo está disponible en Linux</value>
     </data>
+    <data name="StartingRPC" xml:space="preserve">
+        <value>Starting the Discord RPC bridge</value>
+    </data>
+    <data name="UseDiscordRPCBridgeDescription" xml:space="preserve">
+        <value>Check this to enable the Discord Rich Presence Bridge when launching the game (only needed for some Wine/Proton builds).</value>
+    </data>
+    <data name="UseDiscordRPCBridgeSetting" xml:space="preserve">
+        <value>Use Discord Rich Presence Bridge</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortDescription" xml:space="preserve">
+        <value>Set to customize the port Discord RPC communicates on (Port must also be set in the Discord RPC plugin).</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortSetting" xml:space="preserve">
+        <value>Use Custom RPC Port</value>
+    </data>
+    <data name="DiscordRPCCustomPortDescription" xml:space="preserve">
+        <value>Set what port Discord RPC should communicate on.</value>
+    </data>
+    <data name="DiscordRPCCustomPortSetting" xml:space="preserve">
+        <value>Custom RPC Port</value>
+    </data>
+    <data name="PortNumberMustBeBetween" xml:space="preserve">
+        <value>Port number must be between 1024-49151</value>
+    </data>
 </root>

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.fr.resx
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.fr.resx
@@ -571,4 +571,28 @@ Vous allez peut-être devoir réinstaller le jeu.</value>
   <data name="EnableFsyncSettingUnsupportedPlatformValidation" xml:space="preserve">
         <value>FSync n'est disponible que sur Linux</value>
     </data>
+    <data name="StartingRPC" xml:space="preserve">
+        <value>Starting the Discord RPC bridge</value>
+    </data>
+    <data name="UseDiscordRPCBridgeDescription" xml:space="preserve">
+        <value>Check this to enable the Discord Rich Presence Bridge when launching the game (only needed for some Wine/Proton builds).</value>
+    </data>
+    <data name="UseDiscordRPCBridgeSetting" xml:space="preserve">
+        <value>Use Discord Rich Presence Bridge</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortDescription" xml:space="preserve">
+        <value>Set to customize the port Discord RPC communicates on (Port must also be set in the Discord RPC plugin).</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortSetting" xml:space="preserve">
+        <value>Use Custom RPC Port</value>
+    </data>
+    <data name="DiscordRPCCustomPortDescription" xml:space="preserve">
+        <value>Set what port Discord RPC should communicate on.</value>
+    </data>
+    <data name="DiscordRPCCustomPortSetting" xml:space="preserve">
+        <value>Custom RPC Port</value>
+    </data>
+    <data name="PortNumberMustBeBetween" xml:space="preserve">
+        <value>Port number must be between 1024-49151</value>
+    </data>
 </root>

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.hu.resx
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.hu.resx
@@ -571,4 +571,28 @@ Lehetséges, hogy újra kell telepítened a játékot.</value>
   <data name="EnableFsyncSettingUnsupportedPlatformValidation" xml:space="preserve">
         <value>Az FSync csak Linuxon használható.</value>
     </data>
+    <data name="StartingRPC" xml:space="preserve">
+        <value>Starting the Discord RPC bridge</value>
+    </data>
+    <data name="UseDiscordRPCBridgeDescription" xml:space="preserve">
+        <value>Check this to enable the Discord Rich Presence Bridge when launching the game (only needed for some Wine/Proton builds).</value>
+    </data>
+    <data name="UseDiscordRPCBridgeSetting" xml:space="preserve">
+        <value>Use Discord Rich Presence Bridge</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortDescription" xml:space="preserve">
+        <value>Set to customize the port Discord RPC communicates on (Port must also be set in the Discord RPC plugin).</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortSetting" xml:space="preserve">
+        <value>Use Custom RPC Port</value>
+    </data>
+    <data name="DiscordRPCCustomPortDescription" xml:space="preserve">
+        <value>Set what port Discord RPC should communicate on.</value>
+    </data>
+    <data name="DiscordRPCCustomPortSetting" xml:space="preserve">
+        <value>Custom RPC Port</value>
+    </data>
+    <data name="PortNumberMustBeBetween" xml:space="preserve">
+        <value>Port number must be between 1024-49151</value>
+    </data>
 </root>

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.it.resx
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.it.resx
@@ -571,4 +571,28 @@ You may have to reinstall the game.</value>
   <data name="EnableFsyncSettingUnsupportedPlatformValidation" xml:space="preserve">
         <value>FSync is only available on Linux</value>
     </data>
+    <data name="StartingRPC" xml:space="preserve">
+        <value>Starting the Discord RPC bridge</value>
+    </data>
+    <data name="UseDiscordRPCBridgeDescription" xml:space="preserve">
+        <value>Check this to enable the Discord Rich Presence Bridge when launching the game (only needed for some Wine/Proton builds).</value>
+    </data>
+    <data name="UseDiscordRPCBridgeSetting" xml:space="preserve">
+        <value>Use Discord Rich Presence Bridge</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortDescription" xml:space="preserve">
+        <value>Set to customize the port Discord RPC communicates on (Port must also be set in the Discord RPC plugin).</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortSetting" xml:space="preserve">
+        <value>Use Custom RPC Port</value>
+    </data>
+    <data name="DiscordRPCCustomPortDescription" xml:space="preserve">
+        <value>Set what port Discord RPC should communicate on.</value>
+    </data>
+    <data name="DiscordRPCCustomPortSetting" xml:space="preserve">
+        <value>Custom RPC Port</value>
+    </data>
+    <data name="PortNumberMustBeBetween" xml:space="preserve">
+        <value>Port number must be between 1024-49151</value>
+    </data>
 </root>

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.ja.resx
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.ja.resx
@@ -571,4 +571,28 @@ You may have to reinstall the game.</value>
   <data name="EnableFsyncSettingUnsupportedPlatformValidation" xml:space="preserve">
         <value>FSync is only available on Linux</value>
     </data>
+    <data name="StartingRPC" xml:space="preserve">
+        <value>Starting the Discord RPC bridge</value>
+    </data>
+    <data name="UseDiscordRPCBridgeDescription" xml:space="preserve">
+        <value>Check this to enable the Discord Rich Presence Bridge when launching the game (only needed for some Wine/Proton builds).</value>
+    </data>
+    <data name="UseDiscordRPCBridgeSetting" xml:space="preserve">
+        <value>Use Discord Rich Presence Bridge</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortDescription" xml:space="preserve">
+        <value>Set to customize the port Discord RPC communicates on (Port must also be set in the Discord RPC plugin).</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortSetting" xml:space="preserve">
+        <value>Use Custom RPC Port</value>
+    </data>
+    <data name="DiscordRPCCustomPortDescription" xml:space="preserve">
+        <value>Set what port Discord RPC should communicate on.</value>
+    </data>
+    <data name="DiscordRPCCustomPortSetting" xml:space="preserve">
+        <value>Custom RPC Port</value>
+    </data>
+    <data name="PortNumberMustBeBetween" xml:space="preserve">
+        <value>Port number must be between 1024-49151</value>
+    </data>
 </root>

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.ko.resx
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.ko.resx
@@ -571,4 +571,28 @@ ReShade를 사용 중이었다면, 다시 설치해야 합니다.</value>
   <data name="EnableFsyncSettingUnsupportedPlatformValidation" xml:space="preserve">
         <value>FSync는 Linux에서만 사용할 수 있습니다</value>
     </data>
+    <data name="StartingRPC" xml:space="preserve">
+        <value>Starting the Discord RPC bridge</value>
+    </data>
+    <data name="UseDiscordRPCBridgeDescription" xml:space="preserve">
+        <value>Check this to enable the Discord Rich Presence Bridge when launching the game (only needed for some Wine/Proton builds).</value>
+    </data>
+    <data name="UseDiscordRPCBridgeSetting" xml:space="preserve">
+        <value>Use Discord Rich Presence Bridge</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortDescription" xml:space="preserve">
+        <value>Set to customize the port Discord RPC communicates on (Port must also be set in the Discord RPC plugin).</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortSetting" xml:space="preserve">
+        <value>Use Custom RPC Port</value>
+    </data>
+    <data name="DiscordRPCCustomPortDescription" xml:space="preserve">
+        <value>Set what port Discord RPC should communicate on.</value>
+    </data>
+    <data name="DiscordRPCCustomPortSetting" xml:space="preserve">
+        <value>Custom RPC Port</value>
+    </data>
+    <data name="PortNumberMustBeBetween" xml:space="preserve">
+        <value>Port number must be between 1024-49151</value>
+    </data>
 </root>

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.nl.resx
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.nl.resx
@@ -571,4 +571,28 @@ You may have to reinstall the game.</value>
   <data name="EnableFsyncSettingUnsupportedPlatformValidation" xml:space="preserve">
         <value>FSync is only available on Linux</value>
     </data>
+    <data name="StartingRPC" xml:space="preserve">
+        <value>Starting the Discord RPC bridge</value>
+    </data>
+    <data name="UseDiscordRPCBridgeDescription" xml:space="preserve">
+        <value>Check this to enable the Discord Rich Presence Bridge when launching the game (only needed for some Wine/Proton builds).</value>
+    </data>
+    <data name="UseDiscordRPCBridgeSetting" xml:space="preserve">
+        <value>Use Discord Rich Presence Bridge</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortDescription" xml:space="preserve">
+        <value>Set to customize the port Discord RPC communicates on (Port must also be set in the Discord RPC plugin).</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortSetting" xml:space="preserve">
+        <value>Use Custom RPC Port</value>
+    </data>
+    <data name="DiscordRPCCustomPortDescription" xml:space="preserve">
+        <value>Set what port Discord RPC should communicate on.</value>
+    </data>
+    <data name="DiscordRPCCustomPortSetting" xml:space="preserve">
+        <value>Custom RPC Port</value>
+    </data>
+    <data name="PortNumberMustBeBetween" xml:space="preserve">
+        <value>Port number must be between 1024-49151</value>
+    </data>
 </root>

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.no.resx
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.no.resx
@@ -571,4 +571,28 @@ You may have to reinstall the game.</value>
   <data name="EnableFsyncSettingUnsupportedPlatformValidation" xml:space="preserve">
         <value>FSync is only available on Linux</value>
     </data>
+    <data name="StartingRPC" xml:space="preserve">
+        <value>Starting the Discord RPC bridge</value>
+    </data>
+    <data name="UseDiscordRPCBridgeDescription" xml:space="preserve">
+        <value>Check this to enable the Discord Rich Presence Bridge when launching the game (only needed for some Wine/Proton builds).</value>
+    </data>
+    <data name="UseDiscordRPCBridgeSetting" xml:space="preserve">
+        <value>Use Discord Rich Presence Bridge</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortDescription" xml:space="preserve">
+        <value>Set to customize the port Discord RPC communicates on (Port must also be set in the Discord RPC plugin).</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortSetting" xml:space="preserve">
+        <value>Use Custom RPC Port</value>
+    </data>
+    <data name="DiscordRPCCustomPortDescription" xml:space="preserve">
+        <value>Set what port Discord RPC should communicate on.</value>
+    </data>
+    <data name="DiscordRPCCustomPortSetting" xml:space="preserve">
+        <value>Custom RPC Port</value>
+    </data>
+    <data name="PortNumberMustBeBetween" xml:space="preserve">
+        <value>Port number must be between 1024-49151</value>
+    </data>
 </root>

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.pt.resx
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.pt.resx
@@ -571,4 +571,28 @@ You may have to reinstall the game.</value>
   <data name="EnableFsyncSettingUnsupportedPlatformValidation" xml:space="preserve">
         <value>FSync is only available on Linux</value>
     </data>
+    <data name="StartingRPC" xml:space="preserve">
+        <value>Starting the Discord RPC bridge</value>
+    </data>
+    <data name="UseDiscordRPCBridgeDescription" xml:space="preserve">
+        <value>Check this to enable the Discord Rich Presence Bridge when launching the game (only needed for some Wine/Proton builds).</value>
+    </data>
+    <data name="UseDiscordRPCBridgeSetting" xml:space="preserve">
+        <value>Use Discord Rich Presence Bridge</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortDescription" xml:space="preserve">
+        <value>Set to customize the port Discord RPC communicates on (Port must also be set in the Discord RPC plugin).</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortSetting" xml:space="preserve">
+        <value>Use Custom RPC Port</value>
+    </data>
+    <data name="DiscordRPCCustomPortDescription" xml:space="preserve">
+        <value>Set what port Discord RPC should communicate on.</value>
+    </data>
+    <data name="DiscordRPCCustomPortSetting" xml:space="preserve">
+        <value>Custom RPC Port</value>
+    </data>
+    <data name="PortNumberMustBeBetween" xml:space="preserve">
+        <value>Port number must be between 1024-49151</value>
+    </data>
 </root>

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.resx
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.resx
@@ -267,6 +267,12 @@ Can't pass programs (like gamescope -- %command%). Does not accept flatpak args 
     <data name="GameDPIAwarenessSettingDescription" xml:space="preserve">
         <value>Select the game's DPI Awareness. Change this if the game's scaling looks wrong.</value>
     </data>
+    <data name="UseDiscordRPCBridgeSetting" xml:space="preserve">
+        <value>Use Discord Rich Presence Bridge</value>
+    </data>
+    <data name="UseDiscordRPCBridgeDescription" xml:space="preserve">
+        <value>Check this to enable the Discord Rich Presence Bridge when launching the game (only needed for some Wine/Proton builds).</value>
+    </data>
     <data name="UseXLAuthMacrosSetting" xml:space="preserve">
         <value>Use XIVLauncher authenticator/OTP macros</value>
     </data>
@@ -469,6 +475,9 @@ If you want to reinstall FFXIV, please take care to disable it first.</value>
     <data name="PreparingForCompatTool" xml:space="preserve">
         <value>Preparing required compatibility tools</value>
     </data>
+    <data name="StartingRPC" xml:space="preserve">
+        <value>Starting the Discord RPC bridge</value>
+    </data>
     <data name="StartingGame" xml:space="preserve">
         <value>Starting game...</value>
     </data>
@@ -572,5 +581,20 @@ You may have to reinstall the game.</value>
     </data>
     <data name="EnableFsyncSettingUnsupportedPlatformValidation" xml:space="preserve">
         <value>FSync is only available on Linux</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortSetting" xml:space="preserve">
+        <value>Use Custom RPC Port</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortDescription" xml:space="preserve">
+        <value>Set to customize the port Discord RPC communicates on (Port must also be set in the Discord RPC plugin).</value>
+    </data>
+    <data name="DiscordRPCCustomPortSetting" xml:space="preserve">
+        <value>Custom RPC Port</value>
+    </data>
+    <data name="DiscordRPCCustomPortDescription" xml:space="preserve">
+        <value>Set what port Discord RPC should communicate on.</value>
+    </data>
+    <data name="PortNumberMustBeBetween" xml:space="preserve">
+        <value>Port number must be between 1024-49151</value>
     </data>
 </root>

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.ru.resx
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.ru.resx
@@ -571,4 +571,28 @@ You may have to reinstall the game.</value>
   <data name="EnableFsyncSettingUnsupportedPlatformValidation" xml:space="preserve">
         <value>FSync is only available on Linux</value>
     </data>
+    <data name="StartingRPC" xml:space="preserve">
+        <value>Starting the Discord RPC bridge</value>
+    </data>
+    <data name="UseDiscordRPCBridgeDescription" xml:space="preserve">
+        <value>Check this to enable the Discord Rich Presence Bridge when launching the game (only needed for some Wine/Proton builds).</value>
+    </data>
+    <data name="UseDiscordRPCBridgeSetting" xml:space="preserve">
+        <value>Use Discord Rich Presence Bridge</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortDescription" xml:space="preserve">
+        <value>Set to customize the port Discord RPC communicates on (Port must also be set in the Discord RPC plugin).</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortSetting" xml:space="preserve">
+        <value>Use Custom RPC Port</value>
+    </data>
+    <data name="DiscordRPCCustomPortDescription" xml:space="preserve">
+        <value>Set what port Discord RPC should communicate on.</value>
+    </data>
+    <data name="DiscordRPCCustomPortSetting" xml:space="preserve">
+        <value>Custom RPC Port</value>
+    </data>
+    <data name="PortNumberMustBeBetween" xml:space="preserve">
+        <value>Port number must be between 1024-49151</value>
+    </data>
 </root>

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.sv.resx
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.sv.resx
@@ -571,4 +571,28 @@ You may have to reinstall the game.</value>
   <data name="EnableFsyncSettingUnsupportedPlatformValidation" xml:space="preserve">
         <value>FSync is only available on Linux</value>
     </data>
+    <data name="StartingRPC" xml:space="preserve">
+        <value>Starting the Discord RPC bridge</value>
+    </data>
+    <data name="UseDiscordRPCBridgeDescription" xml:space="preserve">
+        <value>Check this to enable the Discord Rich Presence Bridge when launching the game (only needed for some Wine/Proton builds).</value>
+    </data>
+    <data name="UseDiscordRPCBridgeSetting" xml:space="preserve">
+        <value>Use Discord Rich Presence Bridge</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortDescription" xml:space="preserve">
+        <value>Set to customize the port Discord RPC communicates on (Port must also be set in the Discord RPC plugin).</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortSetting" xml:space="preserve">
+        <value>Use Custom RPC Port</value>
+    </data>
+    <data name="DiscordRPCCustomPortDescription" xml:space="preserve">
+        <value>Set what port Discord RPC should communicate on.</value>
+    </data>
+    <data name="DiscordRPCCustomPortSetting" xml:space="preserve">
+        <value>Custom RPC Port</value>
+    </data>
+    <data name="PortNumberMustBeBetween" xml:space="preserve">
+        <value>Port number must be between 1024-49151</value>
+    </data>
 </root>

--- a/src/XIVLauncher.Core/Resources/Localization/Strings.zh.resx
+++ b/src/XIVLauncher.Core/Resources/Localization/Strings.zh.resx
@@ -572,4 +572,28 @@
   <data name="EnableFsyncSettingUnsupportedPlatformValidation" xml:space="preserve">
         <value>FSync 仅在 Linux 系统可用</value>
     </data>
+    <data name="StartingRPC" xml:space="preserve">
+        <value>Starting the Discord RPC bridge</value>
+    </data>
+    <data name="UseDiscordRPCBridgeDescription" xml:space="preserve">
+        <value>Check this to enable the Discord Rich Presence Bridge when launching the game (only needed for some Wine/Proton builds).</value>
+    </data>
+    <data name="UseDiscordRPCBridgeSetting" xml:space="preserve">
+        <value>Use Discord Rich Presence Bridge</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortDescription" xml:space="preserve">
+        <value>Set to customize the port Discord RPC communicates on (Port must also be set in the Discord RPC plugin).</value>
+    </data>
+    <data name="DiscordRPCUseCustomPortSetting" xml:space="preserve">
+        <value>Use Custom RPC Port</value>
+    </data>
+    <data name="DiscordRPCCustomPortDescription" xml:space="preserve">
+        <value>Set what port Discord RPC should communicate on.</value>
+    </data>
+    <data name="DiscordRPCCustomPortSetting" xml:space="preserve">
+        <value>Custom RPC Port</value>
+    </data>
+    <data name="PortNumberMustBeBetween" xml:space="preserve">
+        <value>Port number must be between 1024-49151</value>
+    </data>
 </root>


### PR DESCRIPTION
After discussion with PAC on the ongoing Discord Rich Presence 2.1.0.0 [update](https://github.com/goatcorp/DalamudPluginsD17/pull/9216), a consensus (I think?) was made in which XIVLauncher.Core would be the one handling RPC similarly to XIV On Mac as a replacement fallback from the old WineRPCBridge that the plugin relied on long ago.

I assumed where the runner should be by the class name and structured it similarly to the other Unix entries, I then slid it between the compatibility tools and game startup though given how light the NuGet is, it will probably rarely show the RPC startup text. All settings for Discord RPC is in the Game tab in between the Game DPI dropdown and XIVLauncher Auth.

Hopefully all is good here for merging and to unblock the plugin update. For source of the NuGet, see here: https://github.com/Bronya-Rand/DiscordRPCBridge-Wine