### PR TITLE
Create the game directory before patching if it is missing

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -912,6 +912,10 @@ public class MainPage : Page
             return false;
         }
 
+        // The free space check in PatchManager throws DriveNotFoundException if the game folder was deleted by the user
+        if (!App.Settings.GamePath.Exists)
+            App.Settings.GamePath.Create();
+
         using var installer = new PatchInstaller(App.Settings.GamePath, App.Settings.KeepPatches ?? false);
         using var acquisition = new AriaPatchAcquisition(new FileInfo(Path.Combine(App.Storage.GetFolder("logs").FullName, "aria2.log")));
         Program.Patcher = new PatchManager(acquisition, App.Settings.PatchSpeedLimit, repository, pendingPatches, App.Settings.GamePath,


### PR DESCRIPTION
Fixes #352

When the game folder has been deleted, login still enters the patch flow and PatchManager's free space check calls DriveInfo on the missing path, which throws DriveNotFoundException on Linux and aborts patching with the error from the issue.

PatchManager already creates the patch store directory when it is missing but does nothing for the game directory, so this creates it on the Core side before the patcher starts. With the folder present, the pending patches install as a fresh copy of the game, which matches the workaround the reporter used (creating the folder by hand).

An alternative would be to mirror the patchStore handling for gamePath inside PatchManager itself, but that lives in XIVLauncher.Common. Happy to open a PR against FFXIVQuickLauncher instead if that is the preferred spot for this.